### PR TITLE
Release kafka 2.0.0-0.11.0.0 (automated commit) - Test 1

### DIFF
--- a/repo/packages/K/kafka/40/config.json
+++ b/repo/packages/K/kafka/40/config.json
@@ -1,0 +1,701 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "Apache Kafka",
+          "type": "string",
+          "default": "kafka"
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V0"
+        },
+        "user": {
+          "type": "string",
+          "description": "The user that the service will run as.",
+          "default": "nobody"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "placement_constraint": {
+          "description": "Marathon-style placement constraint for Broker nodes. Example: rack_id:LIKE:rack-foo-.*,rack_id:MAX_PER:2",
+          "type": "string",
+          "default": "hostname:MAX_PER:1"
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "tls": {
+          "description": "Enable TLS support (requires Enterprise DC/OS running in strict security mode).",
+          "type": "boolean",
+          "default": false
+        },
+        "tls_allow_plaintext": {
+          "description": "Keep the plaintext port open when the TLS is enabled. (Allows clients to connect using a non-encrypted connection and takes effect only if the TLS is enabled.)",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "deploy_strategy": {
+          "description": "Deployment phase strategy. See documentation. [serial, serial-canary, parallel-canary, parallel]",
+          "type": "string",
+          "default": "serial",
+          "enum": [
+            "serial",
+            "serial-canary",
+            "parallel-canary",
+            "parallel"
+          ]
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "deploy_strategy"
+      ]
+    },
+    "brokers": {
+      "description": "Kafka broker configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Broker cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Broker mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Kafka process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Kafka broker process.",
+              "default": 512
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Broker disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_type": {
+          "type": "string",
+          "description": "Disk type to be used for storing broker data. See documentation. [ROOT, MOUNT]",
+          "default": "ROOT"
+        },
+        "disk_path": {
+          "type": "string",
+          "description": "Relative path of consistent disk",
+          "default": "kafka-broker-data"
+        },
+        "count": {
+          "description": "Number of brokers to run",
+          "type": "number",
+          "default": 3
+        },
+        "port": {
+          "description": "Port for broker to listen on",
+          "type": "integer",
+          "default": 0
+        },
+        "port_tls": {
+          "description": "Port for broker to listen on for TLS connections, if the TLS is enabled",
+          "type": "integer",
+          "default": 0
+        },
+        "kill_grace_period": {
+          "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `30`",
+          "type": "integer",
+          "default": 30
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "kafka": {
+      "description": "Kafka service configuration properties",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kafka_zookeeper_uri": {
+          "title": "Custom Zookeeper path",
+          "description": "The address of the cluster to be used by Kafka, or empty to use DC/OS' instance. Example: myhost:2181/mynode",
+          "type": "string",
+          "default": ""
+        },
+        "auto_create_topics_enable": {
+          "title": "auto.create.topics.enable",
+          "description": "Enables auto creation of topic on the server",
+          "type": "boolean",
+          "default": true
+        },
+        "kafka_advertise_host_ip": {
+          "description": "Automatically configure advertised.host.name with the tasks' IP address",
+          "type": "boolean",
+          "default": true
+        },
+        "auto_leader_rebalance_enable": {
+          "title": "auto.leader.rebalance.enable",
+          "description": "Enables auto leader balancing. A background thread checks and triggers leader balance if required at regular intervals",
+          "type": "boolean",
+          "default": true
+        },
+        "background_threads": {
+          "title": "background.threads",
+          "description": "The number of threads to use for various background processing tasks",
+          "type": "integer",
+          "default": 10
+        },
+        "compression_type": {
+          "title": "compression.type",
+          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
+          "type": "string",
+          "default": "producer"
+        },
+        "delete_topic_enable": {
+          "title": "delete.topic.enable",
+          "description": "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off",
+          "type": "boolean",
+          "default": false
+        },
+        "leader_imbalance_check_interval_seconds": {
+          "title": "leader.imbalance.check.interval.seconds",
+          "description": "The frequency with which the partition rebalance check is triggered by the controller",
+          "type": "integer",
+          "default": 300
+        },
+        "leader_imbalance_per_broker_percentage": {
+          "title": "leader.imbalance.per.broker.percentage",
+          "description": "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.",
+          "type": "integer",
+          "default": 10
+        },
+        "log_flush_interval_messages": {
+          "title": "log.flush.interval.messages",
+          "description": "The number of messages accumulated on a log partition before messages are flushed to disk",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "log_flush_offset_checkpoint_interval_ms": {
+          "title": "log.flush.offset.checkpoint.interval.ms",
+          "description": "The frequency with which we update the persistent record of the last flush which acts as the log recovery point",
+          "type": "integer",
+          "default": 60000
+        },
+        "log_flush_scheduler_interval_ms": {
+          "title": "log.flush.scheduler.interval.ms",
+          "description": "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "log_retention_bytes": {
+          "title": "log.retention.bytes",
+          "description": "The maximum size of the log before deleting it",
+          "type": "string",
+          "default": "-1"
+        },
+        "log_retention_hours": {
+          "title": "log.retention.hours",
+          "description": "The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property",
+          "type": "integer",
+          "default": 168
+        },
+        "log_roll_hours": {
+          "title": "log.roll.hours",
+          "description": "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property",
+          "type": "integer",
+          "default": 168
+        },
+        "log_roll_jitter_hours": {
+          "title": "log.roll.jitter.hours",
+          "description": "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property",
+          "type": "integer",
+          "default": 0
+        },
+        "log_segment_bytes": {
+          "title": "log.segment.bytes",
+          "description": "The maximum size of a single log file",
+          "type": "integer",
+          "default": 1073741824
+        },
+        "log_segment_delete_delay_ms": {
+          "title": "log.segment.delete.delay.ms",
+          "description": "The amount of time to wait before deleting a file from the filesystem",
+          "type": "integer",
+          "default": 60000
+        },
+        "message_max_bytes": {
+          "title": "message.max.bytes",
+          "description": "The maximum size of message that the server can receive",
+          "type": "integer",
+          "default": 1000012
+        },
+        "min_insync_replicas": {
+          "title": "min.insync.replicas",
+          "description": "define the minimum number of replicas in ISR needed to satisfy a produce request with required.acks=-1 (or all)",
+          "type": "integer",
+          "default": 1
+        },
+        "num_io_threads": {
+          "title": "num.io.thread",
+          "description": "The number of io threads that the server uses for carrying out network requests",
+          "type": "integer",
+          "default": 8
+        },
+        "num_network_threads": {
+          "title": "num.network.threads",
+          "description": "The number of network threads that the server uses for handling network requests",
+          "type": "integer",
+          "default": 3
+        },
+        "num_recovery_threads_per_data_dir": {
+          "title": "num.recovery.threads.per.data.dir",
+          "description": "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown",
+          "type": "integer",
+          "default": 1
+        },
+        "num_replica_fetchers": {
+          "title": "num.replica.fetchers",
+          "description": "Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker.",
+          "type": "integer",
+          "default": 1
+        },
+        "offset_metadata_max_bytes": {
+          "title": "offset.metadata.max.bytes",
+          "description": "The maximum size for a metadata entry associated with an offset commit",
+          "type": "integer",
+          "default": 4096
+        },
+        "offsets_commit_required_acks": {
+          "title": "offsets.commit.required.acks",
+          "description": "The required acks before the commit can be accepted. In general, the default (-1) should not be overridden",
+          "type": "integer",
+          "default": -1
+        },
+        "offsets_commit_timeout_ms": {
+          "title": "offsets.commit.timeout.ms",
+          "description": "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.",
+          "type": "integer",
+          "default": 5000
+        },
+        "offsets_load_buffer_size": {
+          "title": "offsets.load.buffer.size",
+          "description": "Batch size for reading from the offsets segments when loading offsets into the cache.",
+          "type": "integer",
+          "default": 5242880
+        },
+        "offsets_retention_check_interval_ms": {
+          "title": "offsets.retention.check.interval.ms",
+          "description": "Frequency at which to check for stale offsets",
+          "type": "integer",
+          "default": 600000
+        },
+        "offsets_retention_minutes": {
+          "title": "offsets.retention.minutes",
+          "description": "Log retention window in minutes for offsets topic",
+          "type": "integer",
+          "default": 1440
+        },
+        "offsets_topic_compression_codec": {
+          "title": "offsets.topic.compression.codec",
+          "description": "Compression codec for the offsets topic - compression may be used to achieve 'atomic' commits",
+          "type": "integer",
+          "default": 0
+        },
+        "offsets_topic_num_partitions": {
+          "title": "offsets.topic.num.partitions",
+          "description": "The number of partitions for the offset commit topic (should not change after deployment).",
+          "type": "integer",
+          "default": 50
+        },
+        "offsets_topic_replication_factor": {
+          "title": "offsets.topic.replication.factor",
+          "description": "The replication factor for the offsets topic (set higher to ensure availability). To ensure that the effective replication factor of the offsets topic is the configured value, the number of alive brokers has to be at least the replication factor at the time of the first request for the offsets topic. If not, either the offsets topic creation will fail or it will get a replication factor of min(alive brokers, configured replication factor)",
+          "type": "integer",
+          "default": 3
+        },
+        "offsets_topic_segment_bytes": {
+          "title": "offsets.topic.segment.bytes",
+          "description": "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
+          "type": "integer",
+          "default": 104857600
+        },
+        "queued_max_requests": {
+          "title": "queued.max.requests",
+          "description": "The number of queued requests allowed before blocking the network threads ",
+          "type": "integer",
+          "default": 500
+        },
+        "quota_consumer_default": {
+          "title": "quota.consumer.default",
+          "description": "Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "quota_producer_default": {
+          "title": "quota.producer.default",
+          "description": "Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "replica_fetch_max_bytes": {
+          "title": "replica.fetch.max.bytes",
+          "description": "The number of byes of messages to attempt to fetch",
+          "type": "integer",
+          "default": 1048576
+        },
+        "replica_fetch_min_bytes": {
+          "title": "replica.fetch.min.bytes",
+          "description": "Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs",
+          "type": "integer",
+          "default": 1
+        },
+        "replica_fetch_wait_max_ms": {
+          "title": "replica.fetch.wait.max.ms",
+          "description": "Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics",
+          "type": "integer",
+          "default": 500
+        },
+        "replica_high_watermark_checkpoint_interval_ms": {
+          "title": "replica.high.watermark.checkpoint.interval.ms",
+          "description": "The frequency with which the high watermark is saved out to disk",
+          "type": "integer",
+          "default": 5000
+        },
+        "replica_lag_time_max_ms": {
+          "title": "replica.lag.time.max.ms",
+          "description": "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr",
+          "type": "integer",
+          "default": 10000
+        },
+        "replica_socket_receive_buffer_bytes": {
+          "title": "replica.socket.receive.buffer.bytes",
+          "description": "The socket receive buffer for network requests",
+          "type": "integer",
+          "default": 65536
+        },
+        "replica_socket_timeout_ms": {
+          "title": "replica.socket.timeout.ms",
+          "description": "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms",
+          "type": "integer",
+          "default": 30000
+        },
+        "request_timeout_ms": {
+          "title": "request.timeout.ms",
+          "description": "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.",
+          "type": "integer",
+          "default": 30000
+        },
+        "socket_receive_buffer_bytes": {
+          "title": "socket.receive.buffer.bytes",
+          "description": "The SO_RCVBUF buffer of the socket sever sockets",
+          "type": "integer",
+          "default": 102400
+        },
+        "socket_request_max_bytes": {
+          "title": "socket.request.max.bytes",
+          "description": "The maximum number of bytes in a socket request",
+          "type": "integer",
+          "default": 104857600
+        },
+        "socket_send_buffer_bytes": {
+          "title": "socket.send.buffer.bytes",
+          "description": "The SO_SNDBUF buffer of the socket sever sockets",
+          "type": "integer",
+          "default": 102400
+        },
+        "unclean_leader_election_enable": {
+          "title": "unclean.leader.election.enable",
+          "description": "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss",
+          "type": "boolean",
+          "default": true
+        },
+        "zookeeper_session_timeout_ms": {
+          "title": "zookeeper.session.timeout.ms",
+          "description": "Zookeeper session timeout",
+          "type": "integer",
+          "default": 6000
+        },
+        "connections_max_idle_ms": {
+          "title": "connections.max.idle.ms",
+          "description": "Idle connections timeout: the server socket processor threads close the connections that idle more than this",
+          "type": "integer",
+          "default": 600000
+        },
+        "controlled_shutdown_enable": {
+          "title": "controlled.shutdown.enable",
+          "description": "Enable controlled shutdown of the server",
+          "type": "boolean",
+          "default": true
+        },
+        "controlled_shutdown_max_retries": {
+          "title": "controlled.shutdown.max.retries",
+          "description": "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens",
+          "type": "integer",
+          "default": 3
+        },
+        "controlled_shutdown_retry_backoff_ms": {
+          "title": "controlled.shutdown.retry.backoff.ms",
+          "description": "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.",
+          "type": "integer",
+          "default": 5000
+        },
+        "controller_socket_timeout_ms": {
+          "title": "controller.socket.timeout.ms",
+          "description": "The socket timeout for controller-to-broker channels",
+          "type": "integer",
+          "default": 30000
+        },
+        "default_replication_factor": {
+          "title": "default.replication.factor",
+          "description": "Default replication factors for automatically created topics",
+          "type": "integer",
+          "default": 1
+        },
+        "fetch_purgatory_purge_interval_requests": {
+          "title": "fetch.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the fetch request purgatory",
+          "type": "integer",
+          "default": 1000
+        },
+        "group_max_session_timeout_ms": {
+          "title": "group.max.session.timeout.ms",
+          "description": "The maximum allowed session timeout for registered consumers",
+          "type": "integer",
+          "default": 300000
+        },
+        "group_min_session_timeout_ms": {
+          "title": "group.min.session.timeout.ms",
+          "description": "The minimum allowed session timeout for registered consumers",
+          "type": "integer",
+          "default": 6000
+        },
+        "inter_broker_protocol_version": {
+          "type": "string",
+          "title": "inter.broker.protocol.version",
+          "description": "Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped *serially* one broker at a time, *after* all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0, 0.10.1.x, 0.10.2.x, 0.11.0.0. Check ApiVersion for the full list.",
+          "default": "0.11.0.0"
+        },
+        "log_message_format_version": {
+          "type": "string",
+          "title": "log.message.format.version",
+          "description": "Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Similarly it should be left at 0.10.0 until all clients are updated to 0.11.0. This is typically bumped *serially* one broker at a time, *after* all inter-protocol versions are updated. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details.",
+          "default": "0.11.0"
+        },
+        "log_cleaner_backoff_ms": {
+          "title": "log.cleaner.backoff.ms",
+          "description": "The amount of time to sleep when there are no logs to clean",
+          "type": "integer",
+          "default": 15000
+        },
+        "log_cleaner_dedupe_buffer_size": {
+          "title": "log.cleaner.dedupe.buffer.size",
+          "description": "The total memory used for log deduplication across all cleaner threads",
+          "type": "integer",
+          "default": 134217728
+        },
+        "log_cleaner_delete_retention_ms": {
+          "title": "log.cleaner.delete.retention.ms",
+          "description": "How long are delete records retained?",
+          "type": "integer",
+          "default": 86400000
+        },
+        "log_cleaner_enable": {
+          "title": "log.cleaner.enable",
+          "description": "Enable the log cleaner process to run on the server? Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
+          "type": "boolean",
+          "default": true
+        },
+        "log_cleaner_io_buffer_load_factor": {
+          "title": "log.cleaner.io.buffer.load.factor",
+          "description": "Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions",
+          "type": "number",
+          "default": 0.9
+        },
+        "log_cleaner_io_buffer_size": {
+          "title": "log.cleaner.io.buffer.size",
+          "description": "The total memory used for log cleaner I/O buffers across all cleaner threads",
+          "type": "integer",
+          "default": 524288
+        },
+        "log_cleaner_io_max_bytes_per_second": {
+          "title": "log.cleaner.io.max.bytes.per.second",
+          "description": "The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average",
+          "type": "number",
+          "default": 1.7976931348623157e+308
+        },
+        "log_cleaner_min_cleanable_ratio": {
+          "title": "log.cleaner.min.cleanable.ratio",
+          "description": "The minimum ratio of dirty log to total log for a log to eligible for cleaning",
+          "type": "number",
+          "default": 0.5
+        },
+        "log_cleaner_threads": {
+          "title": "log.cleaner.threads",
+          "description": "The number of background threads to use for log cleaning",
+          "type": "integer",
+          "default": 1
+        },
+        "log_cleanup_policy": {
+          "type": "string",
+          "title": "log.cleanup.policy",
+          "description": "The default cleanup policy for segments beyond the retention window, must be either 'delete' or 'compact'",
+          "default": "delete"
+        },
+        "log_index_interval_bytes": {
+          "title": "log.index.interval.bytes",
+          "description": "The interval with which we add an entry to the offset index",
+          "type": "integer",
+          "default": 4096
+        },
+        "log_index_size_max_bytes": {
+          "title": "log.index.size.max.bytes",
+          "description": "The maximum size in bytes of the offset index",
+          "type": "integer",
+          "default": 10485760
+        },
+        "log_preallocate": {
+          "title": "log.preallocate",
+          "description": "Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.",
+          "type": "boolean",
+          "default": false
+        },
+        "log_retention_check_interval_ms": {
+          "title": "log.retention.check.interval.ms",
+          "description": "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion",
+          "type": "integer",
+          "default": 300000
+        },
+        "max_connections_per_ip": {
+          "title": "max.connections.per.ip",
+          "description": "mum number of connections we allow from each ip address",
+          "type": "integer",
+          "default": 2147483647
+        },
+        "max_connections_per_ip_overrides": {
+          "type": "string",
+          "title": "max.connections.per.ip.overrides",
+          "description": "Per-ip or hostname overrides to the default maximum number of connections",
+          "default": ""
+        },
+        "num_partitions": {
+          "title": "num.partitions",
+          "description": "The default number of log partitions per topic",
+          "type": "integer",
+          "default": 1
+        },
+        "producer_purgatory_purge_interval_requests": {
+          "title": "producer.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the producer request purgatory",
+          "type": "integer",
+          "default": 1000
+        },
+        "replica_fetch_backoff_ms": {
+          "title": "replica.fetch.backoff.ms",
+          "description": "The amount of time to sleep when fetch partition error occurs.",
+          "type": "integer",
+          "default": 1000
+        },
+        "reserved_broker_max_id": {
+          "title": "reserved.broker.max.id",
+          "description": "Max number that can be used for a broker.id",
+          "type": "integer",
+          "default": 1000
+        },
+        "kafka_metrics_reporters": {
+          "title": "kafka.metric.reporters",
+          "description": "Old style metrics reporter",
+          "type": "string",
+          "default": "com.airbnb.kafka.kafka08.StatsdMetricsReporter"
+        },
+        "metric_reporters": {
+          "title": "metric.reporters",
+          "description": "Java class to collect/report broker metrics",
+          "type": "string",
+          "default": "com.airbnb.kafka.kafka09.StatsdMetricsReporter"
+        },
+        "metrics_num_samples": {
+          "title": "metrics.num.samples",
+          "description": "The number of samples maintained to compute metrics.",
+          "type": "integer",
+          "default": 2
+        },
+        "metrics_sample_window_ms": {
+          "title": "metrics.sample.window.ms",
+          "description": "The number of samples maintained to compute metrics.",
+          "type": "integer",
+          "default": 30000
+        },
+        "quota_window_num": {
+          "title": "quota.window.num",
+          "description": "The number of samples to retain in memory",
+          "type": "integer",
+          "default": 11
+        },
+        "quota_window_size_seconds": {
+          "title": "quota.window.size.seconds",
+          "description": "The time span of each sample",
+          "type": "integer",
+          "default": 1
+        },
+        "zookeeper_sync_time_ms": {
+          "title": "zookeeper.sync.time.ms",
+          "description": "How far a ZK follower can be behind a ZK leader",
+          "type": "integer",
+          "default": 2000
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/K/kafka/40/marathon.json.mustache
+++ b/repo/packages/K/kafka/40/marathon.json.mustache
@@ -1,0 +1,211 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user":"{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./kafka-scheduler/bin/kafka ./kafka-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    {{#brokers.kill_grace_period}}
+    "BROKER_KILL_GRACE_PERIOD": "{{brokers.kill_grace_period}}",
+    {{/brokers.kill_grace_period}}
+    "CMD_PREFIX": "{{service.cmd_prefix}}",
+    "SECRET_NAME": "{{service.secret_name}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "KAFKA_URI": "{{resource.assets.uris.kafka-tgz}}",
+    "KAFKA_JAVA_URI": "{{resource.assets.uris.kafka-jre-tar-gz}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "KAFKA_STATSD_URI": "{{resource.assets.uris.kafka-statsd-jar}}",
+    "CLIENT_STATSD_URI": "{{resource.assets.uris.statsd-client-jar}}",
+
+    "PLACEMENT_CONSTRAINTS": "{{service.placement_constraint}}",
+    "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",
+    "BROKER_COUNT": "{{brokers.count}}",
+    "BROKER_CPUS": "{{brokers.cpus}}",
+    "BROKER_MEM": "{{brokers.mem}}",
+    "BROKER_DISK_SIZE": "{{brokers.disk}}",
+    "BROKER_DISK_TYPE": "{{brokers.disk_type}}",
+    "BROKER_DISK_PATH": "{{brokers.disk_path}}",
+    "BROKER_JAVA_HEAP": "{{brokers.heap.size}}",
+    "BROKER_PORT": "{{brokers.port}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    {{#service.tls}}
+    "BROKER_PORT_TLS": "{{brokers.port_tls}}",
+    "TASKCFG_ALL_KAFKA_ENABLE_TLS": "{{service.tls}}",
+    {{#service.tls_allow_plaintext}}
+    "TASKCFG_ALL_KAFKA_ALLOW_PLAINTEXT": "{{service.tls_allow_plaintext}}",
+    {{/service.tls_allow_plaintext}}
+    {{/service.tls}}
+
+    "CONFIG_TEMPLATE_PATH": "kafka-scheduler",
+    "KAFKA_VERSION_PATH": "kafka_2.12-0.11.0.0",
+
+    "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
+
+    {{#kafka.kafka_advertise_host_ip}}
+    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "set",
+    {{/kafka.kafka_advertise_host_ip}}
+
+    "TASKCFG_ALL_KAFKA_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_COMPRESSION_CODEC": "{{kafka.offsets_topic_compression_codec}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MIN_BYTES": "{{kafka.replica_fetch_min_bytes}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS": "{{kafka.controlled_shutdown_retry_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_offset_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS": "{{kafka.offsets_topic_num_partitions}}",
+    "TASKCFG_ALL_KAFKA_MAX_CONNECTIONS_PER_IP_OVERRIDES": "{{kafka.max_connections_per_ip_overrides}}",
+    "TASKCFG_ALL_KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS": "{{kafka.leader_imbalance_check_interval_seconds}}",
+    "TASKCFG_ALL_KAFKA_INTER_BROKER_PROTOCOL_VERSION": "{{kafka.inter_broker_protocol_version}}",
+    "TASKCFG_ALL_KAFKA_LOG_MESSAGE_FORMAT_VERSION": "{{kafka.log_message_format_version}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_SOCKET_TIMEOUT_MS": "{{kafka.replica_socket_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_GROUP_MAX_SESSION_TIMEOUT_MS": "{{kafka.group_max_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_DELETE_RETENTION_MS": "{{kafka.log_cleaner_delete_retention_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_PREALLOCATE": "{{kafka.log_preallocate}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.replica_socket_receive_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_OFFSET_METADATA_MAX_BYTES": "{{kafka.offset_metadata_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_MESSAGE_MAX_BYTES": "{{kafka.message_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_JITTER_HOURS": "{{kafka.log_roll_jitter_hours}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_RETENTION_CHECK_INTERVAL_MS": "{{kafka.offsets_retention_check_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.fetch_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS": "{{kafka.log_retention_check_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_INDEX_INTERVAL_BYTES": "{{kafka.log_index_interval_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_NETWORK_THREADS": "{{kafka.num_network_threads}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_COMMIT_TIMEOUT_MS": "{{kafka.offsets_commit_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{kafka.offsets_topic_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MAX_BYTES": "{{kafka.replica_fetch_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_CONNECTIONS_MAX_IDLE_MS": "{{kafka.connections_max_idle_ms}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_REQUEST_MAX_BYTES": "{{kafka.socket_request_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_METRICS_REPORTERS": "{{kafka.kafka_metrics_reporters}}",
+    "TASKCFG_ALL_METRIC_REPORTERS": "{{kafka.metric_reporters}}",
+    "TASKCFG_ALL_KAFKA_METRICS_NUM_SAMPLES": "{{kafka.metrics_num_samples}}",
+    "TASKCFG_ALL_KAFKA_METRICS_SAMPLE_WINDOW_MS": "{{kafka.metrics_sample_window_ms}}",
+    "TASKCFG_ALL_KAFKA_NUM_PARTITIONS": "{{kafka.num_partitions}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_LAG_TIME_MAX_MS": "{{kafka.replica_lag_time_max_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_BUFFER_LOAD_FACTOR": "{{kafka.log_cleaner_io_buffer_load_factor}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_COMMIT_REQUIRED_ACKS": "{{kafka.offsets_commit_required_acks}}",
+    "TASKCFG_ALL_KAFKA_AUTO_CREATE_TOPICS_ENABLE": "{{kafka.auto_create_topics_enable}}",
+    "TASKCFG_ALL_KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE": "{{kafka.unclean_leader_election_enable}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_BACKOFF_MS": "{{kafka.replica_fetch_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_HOURS": "{{kafka.log_roll_hours}}",
+    "TASKCFG_ALL_KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS": "{{kafka.zookeeper_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.producer_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS": "{{kafka.group_min_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_INDEX_SIZE_MAX_BYTES": "{{kafka.log_index_size_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_REPLICA_FETCHERS": "{{kafka.num_replica_fetchers}}",
+    "TASKCFG_ALL_KAFKA_MIN_INSYNC_REPLICAS": "{{kafka.min_insync_replicas}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_INTERVAL_MESSAGES": "{{kafka.log_flush_interval_messages}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_SEND_BUFFER_BYTES": "{{kafka.socket_send_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_AUTO_LEADER_REBALANCE_ENABLE": "{{kafka.auto_leader_rebalance_enable}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_ENABLE": "{{kafka.log_cleaner_enable}}",
+    "TASKCFG_ALL_KAFKA_QUEUED_MAX_REQUESTS": "{{kafka.queued_max_requests}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_MAX_RETRIES": "{{kafka.controlled_shutdown_max_retries}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_LOAD_BUFFER_SIZE": "{{kafka.offsets_load_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_BYTES": "{{kafka.log_retention_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_IO_THREADS": "{{kafka.num_io_threads}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLER_SOCKET_TIMEOUT_MS": "{{kafka.controller_socket_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_HOURS": "{{kafka.log_retention_hours}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_SCHEDULER_INTERVAL_MS": "{{kafka.log_flush_scheduler_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_RETENTION_MINUTES": "{{kafka.offsets_retention_minutes}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.quota_window_size_seconds}}",
+    "TASKCFG_ALL_KAFKA_LOG_SEGMENT_BYTES": "{{kafka.log_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE": "{{kafka.leader_imbalance_per_broker_percentage}}",
+    "TASKCFG_ALL_KAFKA_MAX_CONNECTIONS_PER_IP": "{{kafka.max_connections_per_ip}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_DEDUPE_BUFFER_SIZE": "{{kafka.log_cleaner_dedupe_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO": "{{kafka.log_cleaner_min_cleanable_ratio}}",
+    "TASKCFG_ALL_KAFKA_ZOOKEEPER_SYNC_TIME_MS": "{{kafka.zookeeper_sync_time_ms}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_CONSUMER_DEFAULT": "{{kafka.quota_consumer_default}}",
+    "TASKCFG_ALL_KAFKA_DELETE_TOPIC_ENABLE": "{{kafka.delete_topic_enable}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANUP_POLICY": "{{kafka.log_cleanup_policy}}",
+    "TASKCFG_ALL_KAFKA_DEFAULT_REPLICATION_FACTOR": "{{kafka.default_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR": "{{kafka.num_recovery_threads_per_data_dir}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_BUFFER_SIZE": "{{kafka.log_cleaner_io_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_BACKGROUND_THREADS": "{{kafka.background_threads}}",
+    "TASKCFG_ALL_KAFKA_LOG_SEGMENT_DELETE_DELAY_MS": "{{kafka.log_segment_delete_delay_ms}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_WINDOW_NUM": "{{kafka.quota_window_num}}",
+    "TASKCFG_ALL_KAFKA_REQUEST_TIMEOUT_MS": "{{kafka.request_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_THREADS": "{{kafka.log_cleaner_threads}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_PRODUCER_DEFAULT": "{{kafka.quota_producer_default}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_BACKOFF_MS": "{{kafka.log_cleaner_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_ENABLE": "{{kafka.controlled_shutdown_enable}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.socket_receive_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_WAIT_MAX_MS": "{{kafka.replica_fetch_wait_max_ms}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS": "{{kafka.replica_high_watermark_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
+    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.executor-zip}}",
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.kafka-scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.kafka-tgz}}",
+    "{{resource.assets.uris.jre-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/K/kafka/40/package.json
+++ b/repo/packages/K/kafka/40/package.json
@@ -1,0 +1,19 @@
+{
+  "description": "Apache Kafka",
+  "framework": true,
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.9",
+  "name": "kafka",
+  "packagingVersion": "3.0",
+  "postInstallNotes": "DC/OS Apache Kafka Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/kafka\n\tIssues: https://dcosjira.atlassian.net/projects/KAFKA/issues",
+  "postUninstallNotes": "DC/OS Apache Kafka Service is being uninstalled.\nPlease follow the instructions at https://docs.mesosphere.com/current/usage/service-guides/kafka/uninstall to remove any persistent state if required.",
+  "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM | 1 5000 MB Disk\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
+  "selected": false,
+  "tags": [
+    "message",
+    "broker",
+    "kafka",
+    "pubsub"
+  ],
+  "version": "2.0.0-0.11.0.0"
+}

--- a/repo/packages/K/kafka/40/resource.json
+++ b/repo/packages/K/kafka/40/resource.json
@@ -1,0 +1,60 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "bootstrap-zip": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/bootstrap.zip",
+      "kafka-tgz": "https://s3.us-east-2.amazonaws.com/seglo-fdp-dev/static/kafka_2.12-0.11.0.0.tgz",
+      "kafka-jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
+      "kafka-scheduler-zip": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/kafka-scheduler.zip",
+      "executor-zip": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/executor.zip",
+      "kafka-statsd-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-statsd-metrics2-0.5.3.jar",
+      "statsd-client-jar": "http://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "bd6c7c60788b5e61432e7239f1480506a1a7e144e1d25188737861af509a0449"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/dcos-kafka-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "7c6aa8ba6e61b1b27089d65c604ae21d987efe46bb9dba44c147164f3f041c2b"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/dcos-kafka-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "65e3eeddca21a72295310e310d0cab46ea74646808de42d82c7d8309a10a421c"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/dcos-kafka.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release kafka 2.0.0-0.11.0.0 (automated commit)

Description:
Release kafka 2.0.0-0.11.0.0, scala 2.12, test PR

Changes since revision 39:
0 files added: []
1 files removed: [command.json]
4 files changed:

```
--- 39/config.json
+++ 40/config.json
@@ -1,757 +1,701 @@
 {
-  "type":"object",
-    "properties":{
-      "service":{
-        "type":"object",
-        "description": "DC/OS service configuration properties",
-        "properties":{
-          "name" : {
-            "description":"The name of the Kafka service instance",
-            "type":"string",
-            "default":"kafka"
-          },
-          "user": {
-            "type": "string",
-            "description": "The user that the service will run as.",
-            "default": "root"
-          },
-          "principal": {
-            "description": "The principal for the Kafka service instance.",
-            "type": "string",
-            "default": "kafka-principal"
-          },
-          "secret_name": {
-            "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
-            "type": "string",
-            "default": ""
-          },
-          "placement_constraint":{
-            "description":"Marathon-style placement constraint for Broker nodes. Example: rack_id:LIKE:rack-foo-.*,rack_id:MAX_PER:2",
-            "type":"string",
-            "default":""
-          },
-          "placement_strategy":{
-            "description":"Broker placement strategy. See documentation. [ANY, NODE]",
-            "type":"string",
-            "default":"NODE"
-          },
-          "phase_strategy":{
-            "description":"Broker rollout strategy. See documentation. [INSTALL, STAGE]",
-            "type":"string",
-            "default":"INSTALL"
-          },
-          "enable_replacement":{
-            "description":"Enable automated replacement of Brokers. WARNING: May cause data loss. See documentation.",
-            "type":"boolean",
-            "default":false
-          },
-          "recover_in_place_grace_period_secs":{
-            "description":"The minimum amount of time (in seconds) which must pass before a Broker may be destructively replaced.",
-            "type":"number",
-            "default":1200
-          },
-          "min_delay_between_recovers_secs":{
-            "description":"The minimum amount of time (in seconds) which must pass between destructive replacements of Brokers.",
-            "type":"number",
-            "default":600
-          },
-          "enable_health_check":{
-            "description":"Enable automated detection of Broker failures which did not result in a Broker process exit.",
-            "type":"boolean",
-            "default":false
-          },
-          "health_check_delay_sec":{
-            "description":"The period of time (in seconds) waited before the health-check begins execution.",
-            "type":"number",
-            "default":15
-          },
-          "health_check_interval_sec":{
-            "description":"The period of time (in seconds) between health-check executions.",
-            "type":"number",
-            "default":10
-          },
-          "health_check_timeout_sec":{
-            "description":"The duration (in seconds) allowed for a health-check to complete before it is considered a failure.",
-            "type":"number",
-            "default":20
-          },
-          "health_check_grace_period_sec":{
-            "description":"The period of time after the delay (in seconds) before health-check failures count towards the maximum consecutive failures.",
-            "type":"number",
-            "default":10
-          },
-          "health_check_max_consecutive_failures":{
-            "description":"The the number of consecutive failures which cause a Broker process to exit.",
-            "type":"number",
-            "default":3
-          }
-        },
-        "required":[
-          "placement_strategy",
-          "phase_strategy"
-        ]
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "Apache Kafka",
+          "type": "string",
+          "default": "kafka"
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V0"
+        },
+        "user": {
+          "type": "string",
+          "description": "The user that the service will run as.",
+          "default": "nobody"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "placement_constraint": {
+          "description": "Marathon-style placement constraint for Broker nodes. Example: rack_id:LIKE:rack-foo-.*,rack_id:MAX_PER:2",
+          "type": "string",
+          "default": "hostname:MAX_PER:1"
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "tls": {
+          "description": "Enable TLS support (requires Enterprise DC/OS running in strict security mode).",
+          "type": "boolean",
+          "default": false
+        },
+        "tls_allow_plaintext": {
+          "description": "Keep the plaintext port open when the TLS is enabled. (Allows clients to connect using a non-encrypted connection and takes effect only if the TLS is enabled.)",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "deploy_strategy": {
+          "description": "Deployment phase strategy. See documentation. [serial, serial-canary, parallel-canary, parallel]",
+          "type": "string",
+          "default": "serial",
+          "enum": [
+            "serial",
+            "serial-canary",
+            "parallel-canary",
+            "parallel"
+          ]
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
       },
-      "brokers":{
-        "description":"Kafka broker configuration properties",
-        "type":"object",
-        "properties":{
-          "cpus":{
-            "description":"Broker cpu requirements",
-            "type":"number",
-            "default":1.0
-          },
-          "mem":{
-            "description":"Broker mem requirements",
-            "type":"integer",
-            "default":2304
-          },
-          "heap":{
-            "description":"The Kafka process JVM heap configuration object",
-            "type":"object",
-            "properties":{
-              "size": {
-                "type":"integer",
-                "description":"The amound of JVM heap, in MB, allocated to the Kafka broker process.",
-                "default": 2048
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "size"
-            ]
-          },
-          "disk":{
-            "description":"Broker disk requirements (only respected with persistent volumes)",
-            "type":"integer",
-            "default":5000
-          },
-          "disk_type": {
-            "type": "string",
-            "description": "Disk type to be used for storing broker data. See documentation. [ROOT, MOUNT]",
-            "default": "ROOT"
-          },
-          "count":{
-            "description":"Number of brokers to run",
-            "type":"number",
-            "default":3
-          },
-          "port": {
-            "description": "Port for broker to listen on",
-            "type": "integer",
-            "default": 0
-          },
-          "jmx": {
-            "description":"JMX options",
-            "type":"object",
-            "properties": {
-              "enable": {
-                "description": "Whether to enable JMX options",
-                "type": "boolean",
-                "default": false
-              },
-              "remote": {
-                "description": "Whether to enable remote monitoring",
-                "type": "boolean",
-                "default": false
-              },
-              "remote_port": {
-                "description": "Port number for Kafka access",
-                "type": "integer",
-                "default": 9999
-              },
-              "remote_registry_ssl": {
-                "description": "Whether to protect the remote RMI registry using SSL",
-                "type": "boolean",
-                "default": false
-              },
-              "remote_ssl": {
-                "description": "Whether to enable SSL for remote access",
-                "type": "boolean",
-                "default": false
-              },
-              "remote_authenticate": {
-                "description": "Whether to enable password authentication for remote access",
-                "type": "boolean",
-                "default": false
-              },
-              "remote_ssl_need_client_auth": {
-                "description": "Whether to enable SSL client authentication for remote access",
-                "type": "boolean",
-                "default": false
-              }
+      "required": [
+        "deploy_strategy"
+      ]
+    },
+    "brokers": {
+      "description": "Kafka broker configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Broker cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Broker mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Kafka process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Kafka broker process.",
+              "default": 512
             }
           },
-          "statsd": {
-            "description":"Statsd configuration",
-            "type":"object",
-            "properties": {
-              "host": {
-                "description": "Statsd UDP output host",
-                "type": "string",
-                "default": ""
-              },
-              "port": {
-                "description": "Statsd UDP output port",
-                "type": "integer",
-                "default": 0
-              }
-            }
-          }
-        },
-        "required":[
-          "cpus",
-          "mem",
-          "disk",
-          "count"
-        ]
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Broker disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_type": {
+          "type": "string",
+          "description": "Disk type to be used for storing broker data. See documentation. [ROOT, MOUNT]",
+          "default": "ROOT"
+        },
+        "disk_path": {
+          "type": "string",
+          "description": "Relative path of consistent disk",
+          "default": "kafka-broker-data"
+        },
+        "count": {
+          "description": "Number of brokers to run",
+          "type": "number",
+          "default": 3
+        },
+        "port": {
+          "description": "Port for broker to listen on",
+          "type": "integer",
+          "default": 0
+        },
+        "port_tls": {
+          "description": "Port for broker to listen on for TLS connections, if the TLS is enabled",
+          "type": "integer",
+          "default": 0
+        },
+        "kill_grace_period": {
+          "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `30`",
+          "type": "integer",
+          "default": 30
+        }
       },
-      "executor":{
-        "description":"Kafka executor configuration properties",
-        "type":"object",
-        "properties":{
-          "cpus":{
-            "description":"Executor cpu requirements",
-            "type":"number",
-            "default":0.5
-          },
-          "mem":{
-            "description":"Executor mem requirements",
-            "type":"integer",
-            "default":256
-          },
-          "disk":{
-            "description":"Executor disk requirements",
-            "type":"integer",
-            "default":0
-          }
-        },
-        "required":[
-          "cpus",
-          "mem",
-          "disk"
-        ]
-      },
-      "kafka":{
-        "description":"Kafka service configuration properties",
-        "type":"object",
-        "additionalProperties":false,
-        "properties":{
-          "kafka_zookeeper_uri":{
-            "title":"The address of the Zookeeper cluster used by Kafka.",
-            "description":"This should be the address of the Zookeeper cluster Kafka will use.",
-            "type":"string",
-            "default":"master.mesos:2181"
-          },
-          "kafka_advertise_host_ip":{
-            "description":"Automatically configure advertised.host.name with the IP address detected by /opt/mesosphere/detect_ip",
-            "type":"boolean",
-            "default":true
-          },
-          "auto_create_topics_enable":{
-            "title":"auto.create.topics.enable",
-            "description":"Enables auto creation of topic on the server",
-            "type":"boolean",
-            "default":true
-          },
-          "auto_leader_rebalance_enable":{
-            "title":"auto.leader.rebalance.enable",
-            "description":"Enables auto leader balancing. A background thread checks and triggers leader balance if required at regular intervals",
-            "type":"boolean",
-            "default":true
-          },
-          "background_threads":{
-            "title":"background.threads",
-            "description":"The number of threads to use for various background processing tasks",
-            "type":"integer",
-            "default":10
-          },
-          "compression_type":{
-            "title":"compression.type",
-            "description":"Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
-            "type":"string",
-            "default":"producer"
-          },
-          "delete_topic_enable":{
-            "title":"delete.topic.enable",
-            "description":"Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off",
-            "type":"boolean",
-            "default":false
-          },
-          "leader_imbalance_check_interval_seconds":{
-            "title":"leader.imbalance.check.interval.seconds",
-            "description":"The frequency with which the partition rebalance check is triggered by the controller",
-            "type":"integer",
-            "default":300
-          },
-          "leader_imbalance_per_broker_percentage":{
-            "title":"leader.imbalance.per.broker.percentage",
-            "description":"The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.",
-            "type":"integer",
-            "default":10
-          },
-          "log_flush_interval_messages":{
-            "title":"log.flush.interval.messages",
-            "description":"The number of messages accumulated on a log partition before messages are flushed to disk",
-            "type":"string",
-            "default":"9223372036854775807"
-          },
-          "log_flush_offset_checkpoint_interval_ms":{
-            "title":"log.flush.offset.checkpoint.interval.ms",
-            "description":"The frequency with which we update the persistent record of the last flush which acts as the log recovery point",
-            "type":"integer",
-            "default":60000
-          },
-          "log_flush_scheduler_interval_ms":{
-            "title":"log.flush.scheduler.interval.ms",
-            "description":"The frequency in ms that the log flusher checks whether any log needs to be flushed to disk",
-            "type":"string",
-            "default":"9223372036854775807"
-          },
-          "log_retention_bytes":{
-            "title":"log.retention.bytes",
-            "description":"The maximum size of the log before deleting it",
-            "type":"string",
-            "default":"-1"
-          },
-          "log_retention_hours":{
-            "title":"log.retention.hours",
-            "description":"The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property",
-            "type":"integer",
-            "default":168
-          },
-          "log_roll_hours":{
-            "title":"log.roll.hours",
-            "description":"The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property",
-            "type":"integer",
-            "default":168
-          },
-          "log_roll_jitter_hours":{
-            "title":"log.roll.jitter.hours",
-            "description":"The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property",
-            "type":"integer",
-            "default":0
-          },
-          "log_segment_bytes":{
-            "title":"log.segment.bytes",
-            "description":"The maximum size of a single log file",
-            "type":"integer",
-            "default":1073741824
-          },
-          "log_segment_delete_delay_ms":{
-            "title":"log.segment.delete.delay.ms",
-            "description":"The amount of time to wait before deleting a file from the filesystem",
-            "type":"integer",
-            "default":60000
-          },
-          "message_max_bytes":{
-            "title":"message.max.bytes",
-            "description":"The maximum size of message that the server can receive",
-            "type":"integer",
-            "default":1000012
-          },
-          "min_insync_replicas":{
-            "title":"min.insync.replicas",
-            "description":"define the minimum number of replicas in ISR needed to satisfy a produce request with required.acks=-1 (or all)",
-            "type":"integer",
-            "default":1
-          },
-          "num_io_threads":{
-            "title":"num.io.thread",
-            "description":"The number of io threads that the server uses for carrying out network requests",
-            "type":"integer",
-            "default":8
-          },
-          "num_network_threads":{
-            "title":"num.network.threads",
-            "description":"The number of network threads that the server uses for handling network requests",
-            "type":"integer",
-            "default":3
-          },
-          "num_recovery_threads_per_data_dir":{
-            "title":"num.recovery.threads.per.data.dir",
-            "description":"The number of threads per data directory to be used for log recovery at startup and flushing at shutdown",
-            "type":"integer",
-            "default":1
-          },
-          "num_replica_fetchers":{
-            "title":"num.replica.fetchers",
-            "description":"Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker.",
-            "type":"integer",
-            "default":1
-          },
-          "offset_metadata_max_bytes":{
-            "title":"offset.metadata.max.bytes",
-            "description":"The maximum size for a metadata entry associated with an offset commit",
-            "type":"integer",
-            "default":4096
-          },
-          "offsets_commit_required_acks":{
-            "title":"offsets.commit.required.acks",
-            "description":"The required acks before the commit can be accepted. In general, the default (-1) should not be overridden",
-            "type":"integer",
-            "default":-1
-          },
-          "offsets_commit_timeout_ms":{
-            "title":"offsets.commit.timeout.ms",
-            "description":"Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.",
-            "type":"integer",
-            "default":5000
-          },
-          "offsets_load_buffer_size":{
-            "title":"offsets.load.buffer.size",
-            "description":"Batch size for reading from the offsets segments when loading offsets into the cache.",
-            "type":"integer",
-            "default":5242880
-          },
-          "offsets_retention_check_interval_ms":{
-            "title":"offsets.retention.check.interval.ms",
-            "description":"Frequency at which to check for stale offsets",
-            "type":"integer",
-            "default":600000
-          },
-          "offsets_retention_minutes":{
-            "title":"offsets.retention.minutes",
-            "description":"Log retention window in minutes for offsets topic",
-            "type":"integer",
-            "default":1440
-          },
-          "offsets_topic_compression_codec":{
-            "title":"offsets.topic.compression.codec",
-            "description":"Compression codec for the offsets topic - compression may be used to achieve 'atomic' commits",
-            "type":"integer",
-            "default":0
-          },
-          "offsets_topic_num_partitions":{
-            "title":"offsets.topic.num.partitions",
-            "description":"The number of partitions for the offset commit topic (should not change after deployment).",
-            "type":"integer",
-            "default":50
-          },
-          "offsets_topic_replication_factor":{
-            "title":"offsets.topic.replication.factor",
-            "description":"The replication factor for the offsets topic (set higher to ensure availability). To ensure that the effective replication factor of the offsets topic is the configured value, the number of alive brokers has to be at least the replication factor at the time of the first request for the offsets topic. If not, either the offsets topic creation will fail or it will get a replication factor of min(alive brokers, configured replication factor)",
-            "type":"integer",
-            "default":3
-          },
-          "offsets_topic_segment_bytes":{
-            "title":"offsets.topic.segment.bytes",
-            "description":"The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
-            "type":"integer",
-            "default":104857600
-          },
-          "queued_max_requests":{
-            "title":"queued.max.requests",
-            "description":"The number of queued requests allowed before blocking the network threads ",
-            "type":"integer",
-            "default":500
-          },
-          "quota_consumer_default":{
-            "title":"quota.consumer.default",
-            "description":"Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
-            "type":"string",
-            "default":"9223372036854775807"
-          },
-          "quota_producer_default":{
-            "title":"quota.producer.default",
-            "description":"Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
-            "type":"string",
-            "default":"9223372036854775807"
-          },
-          "replica_fetch_max_bytes":{
-            "title":"replica.fetch.max.bytes",
-            "description":"The number of byes of messages to attempt to fetch",
-            "type":"integer",
-            "default":1048576
-          },
-          "replica_fetch_min_bytes":{
-            "title":"replica.fetch.min.bytes",
-            "description":"Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs",
-            "type":"integer",
-            "default":1
-          },
-          "replica_fetch_wait_max_ms":{
-            "title":"replica.fetch.wait.max.ms",
-            "description":"Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics",
-            "type":"integer",
-            "default":500
-          },
-          "replica_high_watermark_checkpoint_interval_ms":{
-            "title":"replica.high.watermark.checkpoint.interval.ms",
-            "description":"The frequency with which the high watermark is saved out to disk",
-            "type":"integer",
-            "default":5000
-          },
-          "replica_lag_time_max_ms":{
-            "title":"replica.lag.time.max.ms",
-            "description":"If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr",
-            "type":"integer",
-            "default":10000
-          },
-          "replica_socket_receive_buffer_bytes":{
-            "title":"replica.socket.receive.buffer.bytes",
-            "description":"The socket receive buffer for network requests",
-            "type":"integer",
-            "default":65536
-          },
-          "replica_socket_timeout_ms":{
-            "title":"replica.socket.timeout.ms",
-            "description":"The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms",
-            "type":"integer",
-            "default":30000
-          },
-          "request_timeout_ms":{
-            "title":"request.timeout.ms",
-            "description":"The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.",
-            "type":"integer",
-            "default":30000
-          },
-          "socket_receive_buffer_bytes":{
-            "title":"socket.receive.buffer.bytes",
-            "description":"The SO_RCVBUF buffer of the socket sever sockets",
-            "type":"integer",
-            "default":102400
-          },
-          "socket_request_max_bytes":{
-            "title":"socket.request.max.bytes",
-            "description":"The maximum number of bytes in a socket request",
-            "type":"integer",
-            "default":104857600
-          },
-          "socket_send_buffer_bytes":{
-            "title":"socket.send.buffer.bytes",
-            "description":"The SO_SNDBUF buffer of the socket sever sockets",
-            "type":"integer",
-            "default":102400
-          },
-          "unclean_leader_election_enable":{
-            "title":"unclean.leader.election.enable",
-            "description":"Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss",
-            "type":"boolean",
-            "default":true
-          },
-          "zookeeper_session_timeout_ms":{
-            "title":"zookeeper.session.timeout.ms",
-            "description":"Zookeeper session timeout",
-            "type":"integer",
-            "default":6000
-          },
-          "connections_max_idle_ms":{
-            "title":"connections.max.idle.ms",
-            "description":"Idle connections timeout: the server socket processor threads close the connections that idle more than this",
-            "type":"integer",
-            "default":600000
-          },
-          "controlled_shutdown_enable":{
-            "title":"controlled.shutdown.enable",
-            "description":"Enable controlled shutdown of the server",
-            "type":"boolean",
-            "default":true
-          },
-          "controlled_shutdown_max_retries":{
-            "title":"controlled.shutdown.max.retries",
-            "description":"Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens",
-            "type":"integer",
-            "default":3
-          },
-          "controlled_shutdown_retry_backoff_ms":{
-            "title":"controlled.shutdown.retry.backoff.ms",
-            "description":"Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.",
-            "type":"integer",
-            "default":5000
-          },
-          "controller_socket_timeout_ms":{
-            "title":"controller.socket.timeout.ms",
-            "description":"The socket timeout for controller-to-broker channels",
-            "type":"integer",
-            "default":30000
-          },
-          "default_replication_factor":{
-            "title":"default.replication.factor",
-            "description":"Default replication factors for automatically created topics",
-            "type":"integer",
-            "default":1
-          },
-          "fetch_purgatory_purge_interval_requests":{
-            "title":"fetch.purgatory.purge.interval.requests",
-            "description":"The purge interval (in number of requests) of the fetch request purgatory",
-            "type":"integer",
-            "default":1000
-          },
-          "group_max_session_timeout_ms":{
-            "title":"group.max.session.timeout.ms",
-            "description":"The maximum allowed session timeout for registered consumers",
-            "type":"integer",
-            "default":300000
-          },
-          "group_min_session_timeout_ms":{
-            "title":"group.min.session.timeout.ms",
-            "description":"The minimum allowed session timeout for registered consumers",
-            "type":"integer",
-            "default":6000
-          },
-          "inter_broker_protocol_version":{
-            "type":"string",
-            "title":"inter.broker.protocol.version",
-            "description":"Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped after all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0. Check ApiVersion for the full list.",
-            "default":"0.10.0.0"
-          },
-          "log_message_format_version":{
-            "type":"string",
-            "title":"log.message.format.version",
-            "description":"Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details.",
-            "default":"0.10.0"
-          },
-          "log_cleaner_backoff_ms":{
-            "title":"log.cleaner.backoff.ms",
-            "description":"The amount of time to sleep when there are no logs to clean",
-            "type":"integer",
-            "default":15000
-          },
-          "log_cleaner_dedupe_buffer_size":{
-            "title":"log.cleaner.dedupe.buffer.size",
-            "description":"The total memory used for log deduplication across all cleaner threads",
-            "type":"integer",
-            "default":134217728
-          },
-          "log_cleaner_delete_retention_ms":{
-            "title":"log.cleaner.delete.retention.ms",
-            "description":"How long are delete records retained?",
-            "type":"integer",
-            "default":86400000
-          },
-          "log_cleaner_enable":{
-            "title":"log.cleaner.enable",
-            "description":"Enable the log cleaner process to run on the server? Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
-            "type":"boolean",
-            "default":true
-          },
-          "log_cleaner_io_buffer_load_factor":{
-            "title":"log.cleaner.io.buffer.load.factor",
-            "description":"Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions",
-            "type":"number",
-            "default":0.9
-          },
-          "log_cleaner_io_buffer_size":{
-            "title":"log.cleaner.io.buffer.size",
-            "description":"The total memory used for log cleaner I/O buffers across all cleaner threads",
-            "type":"integer",
-            "default":524288
-          },
-          "log_cleaner_io_max_bytes_per_second":{
-            "title":"log.cleaner.io.max.bytes.per.second",
-            "description":"The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average",
-            "type":"number",
-            "default":1.7976931348623157E308
-          },
-          "log_cleaner_min_cleanable_ratio":{
-            "title":"log.cleaner.min.cleanable.ratio",
-            "description":"The minimum ratio of dirty log to total log for a log to eligible for cleaning",
-            "type":"number",
-            "default":0.5
-          },
-          "log_cleaner_threads":{
-            "title":"log.cleaner.threads",
-            "description":"The number of background threads to use for log cleaning",
-            "type":"integer",
-            "default":1
-          },
-          "log_cleanup_policy":{
-            "type":"string",
-            "title":"log.cleanup.policy",
-            "description":"The default cleanup policy for segments beyond the retention window, must be either 'delete' or 'compact'",
-            "default":"delete"
-          },
-          "log_index_interval_bytes":{
-            "title":"log.index.interval.bytes",
-            "description":"The interval with which we add an entry to the offset index",
-            "type":"integer",
-            "default":4096
-          },
-          "log_index_size_max_bytes":{
-            "title":"log.index.size.max.bytes",
-            "description":"The maximum size in bytes of the offset index",
-            "type":"integer",
-            "default":10485760
-          },
-          "log_preallocate":{
-            "title":"log.preallocate",
-            "description":"Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.",
-            "type":"boolean",
-            "default":false
-          },
-          "log_retention_check_interval_ms":{
-            "title":"log.retention.check.interval.ms",
-            "description":"The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion",
-            "type":"integer",
-            "default":300000
-          },
-          "max_connections_per_ip":{
-            "title":"max.connections.per.ip",
-            "description":"mum number of connections we allow from each ip address",
-            "type":"integer",
-            "default":2147483647
-          },
-          "max_connections_per_ip_overrides":{
-            "type":"string",
-            "title":"max.connections.per.ip.overrides",
-            "description":"Per-ip or hostname overrides to the default maximum number of connections",
-            "default":""
-          },
-          "num_partitions":{
-            "title":"num.partitions",
-            "description":"The default number of log partitions per topic",
-            "type":"integer",
-            "default":1
-          },
-          "producer_purgatory_purge_interval_requests":{
-            "title":"producer.purgatory.purge.interval.requests",
-            "description":"The purge interval (in number of requests) of the producer request purgatory",
-            "type":"integer",
-            "default":1000
-          },
-          "replica_fetch_backoff_ms":{
-            "title":"replica.fetch.backoff.ms",
-            "description":"The amount of time to sleep when fetch partition error occurs.",
-            "type":"integer",
-            "default":1000
-          },
-          "reserved_broker_max_id":{
-            "title":"reserved.broker.max.id",
-            "description":"Max number that can be used for a broker.id",
-            "type":"integer",
-            "default":1000
-          },
-          "metrics_num_samples":{
-            "title":"metrics.num.samples",
-            "description":"The number of samples maintained to compute metrics.",
-            "type":"integer",
-            "default":2
-          },
-          "metrics_sample_window_ms":{
-            "title":"metrics.sample.window.ms",
-            "description":"The number of samples maintained to compute metrics.",
-            "type":"integer",
-            "default":30000
-          },
-          "quota_window_num":{
-            "title":"quota.window.num",
-            "description":"The number of samples to retain in memory",
-            "type":"integer",
-            "default":11
-          },
-          "quota_window_size_seconds":{
-            "title":"quota.window.size.seconds",
-            "description":"The time span of each sample",
-            "type":"integer",
-            "default":1
-          },
-          "zookeeper_sync_time_ms":{
-            "title":"zookeeper.sync.time.ms",
-            "description":"How far a ZK follower can be behind a ZK leader",
-            "type":"integer",
-            "default":2000
-          }
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "kafka": {
+      "description": "Kafka service configuration properties",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kafka_zookeeper_uri": {
+          "title": "Custom Zookeeper path",
+          "description": "The address of the cluster to be used by Kafka, or empty to use DC/OS' instance. Example: myhost:2181/mynode",
+          "type": "string",
+          "default": ""
+        },
+        "auto_create_topics_enable": {
+          "title": "auto.create.topics.enable",
+          "description": "Enables auto creation of topic on the server",
+          "type": "boolean",
+          "default": true
+        },
+        "kafka_advertise_host_ip": {
+          "description": "Automatically configure advertised.host.name with the tasks' IP address",
+          "type": "boolean",
+          "default": true
+        },
+        "auto_leader_rebalance_enable": {
+          "title": "auto.leader.rebalance.enable",
+          "description": "Enables auto leader balancing. A background thread checks and triggers leader balance if required at regular intervals",
+          "type": "boolean",
+          "default": true
+        },
+        "background_threads": {
+          "title": "background.threads",
+          "description": "The number of threads to use for various background processing tasks",
+          "type": "integer",
+          "default": 10
+        },
+        "compression_type": {
+          "title": "compression.type",
+          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
+          "type": "string",
+          "default": "producer"
+        },
+        "delete_topic_enable": {
+          "title": "delete.topic.enable",
+          "description": "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off",
+          "type": "boolean",
+          "default": false
+        },
+        "leader_imbalance_check_interval_seconds": {
+          "title": "leader.imbalance.check.interval.seconds",
+          "description": "The frequency with which the partition rebalance check is triggered by the controller",
+          "type": "integer",
+          "default": 300
+        },
+        "leader_imbalance_per_broker_percentage": {
+          "title": "leader.imbalance.per.broker.percentage",
+          "description": "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.",
+          "type": "integer",
+          "default": 10
+        },
+        "log_flush_interval_messages": {
+          "title": "log.flush.interval.messages",
+          "description": "The number of messages accumulated on a log partition before messages are flushed to disk",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "log_flush_offset_checkpoint_interval_ms": {
+          "title": "log.flush.offset.checkpoint.interval.ms",
+          "description": "The frequency with which we update the persistent record of the last flush which acts as the log recovery point",
+          "type": "integer",
+          "default": 60000
+        },
+        "log_flush_scheduler_interval_ms": {
+          "title": "log.flush.scheduler.interval.ms",
+          "description": "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "log_retention_bytes": {
+          "title": "log.retention.bytes",
+          "description": "The maximum size of the log before deleting it",
+          "type": "string",
+          "default": "-1"
+        },
+        "log_retention_hours": {
+          "title": "log.retention.hours",
+          "description": "The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property",
+          "type": "integer",
+          "default": 168
+        },
+        "log_roll_hours": {
+          "title": "log.roll.hours",
+          "description": "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property",
+          "type": "integer",
+          "default": 168
+        },
+        "log_roll_jitter_hours": {
+          "title": "log.roll.jitter.hours",
+          "description": "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property",
+          "type": "integer",
+          "default": 0
+        },
+        "log_segment_bytes": {
+          "title": "log.segment.bytes",
+          "description": "The maximum size of a single log file",
+          "type": "integer",
+          "default": 1073741824
+        },
+        "log_segment_delete_delay_ms": {
+          "title": "log.segment.delete.delay.ms",
+          "description": "The amount of time to wait before deleting a file from the filesystem",
+          "type": "integer",
+          "default": 60000
+        },
+        "message_max_bytes": {
+          "title": "message.max.bytes",
+          "description": "The maximum size of message that the server can receive",
+          "type": "integer",
+          "default": 1000012
+        },
+        "min_insync_replicas": {
+          "title": "min.insync.replicas",
+          "description": "define the minimum number of replicas in ISR needed to satisfy a produce request with required.acks=-1 (or all)",
+          "type": "integer",
+          "default": 1
+        },
+        "num_io_threads": {
+          "title": "num.io.thread",
+          "description": "The number of io threads that the server uses for carrying out network requests",
+          "type": "integer",
+          "default": 8
+        },
+        "num_network_threads": {
+          "title": "num.network.threads",
+          "description": "The number of network threads that the server uses for handling network requests",
+          "type": "integer",
+          "default": 3
+        },
+        "num_recovery_threads_per_data_dir": {
+          "title": "num.recovery.threads.per.data.dir",
+          "description": "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown",
+          "type": "integer",
+          "default": 1
+        },
+        "num_replica_fetchers": {
+          "title": "num.replica.fetchers",
+          "description": "Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker.",
+          "type": "integer",
+          "default": 1
+        },
+        "offset_metadata_max_bytes": {
+          "title": "offset.metadata.max.bytes",
+          "description": "The maximum size for a metadata entry associated with an offset commit",
+          "type": "integer",
+          "default": 4096
+        },
+        "offsets_commit_required_acks": {
+          "title": "offsets.commit.required.acks",
+          "description": "The required acks before the commit can be accepted. In general, the default (-1) should not be overridden",
+          "type": "integer",
+          "default": -1
+        },
+        "offsets_commit_timeout_ms": {
+          "title": "offsets.commit.timeout.ms",
+          "description": "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.",
+          "type": "integer",
+          "default": 5000
+        },
+        "offsets_load_buffer_size": {
+          "title": "offsets.load.buffer.size",
+          "description": "Batch size for reading from the offsets segments when loading offsets into the cache.",
+          "type": "integer",
+          "default": 5242880
+        },
+        "offsets_retention_check_interval_ms": {
+          "title": "offsets.retention.check.interval.ms",
+          "description": "Frequency at which to check for stale offsets",
+          "type": "integer",
+          "default": 600000
+        },
+        "offsets_retention_minutes": {
+          "title": "offsets.retention.minutes",
+          "description": "Log retention window in minutes for offsets topic",
+          "type": "integer",
+          "default": 1440
+        },
+        "offsets_topic_compression_codec": {
+          "title": "offsets.topic.compression.codec",
+          "description": "Compression codec for the offsets topic - compression may be used to achieve 'atomic' commits",
+          "type": "integer",
+          "default": 0
+        },
+        "offsets_topic_num_partitions": {
+          "title": "offsets.topic.num.partitions",
+          "description": "The number of partitions for the offset commit topic (should not change after deployment).",
+          "type": "integer",
+          "default": 50
+        },
+        "offsets_topic_replication_factor": {
+          "title": "offsets.topic.replication.factor",
+          "description": "The replication factor for the offsets topic (set higher to ensure availability). To ensure that the effective replication factor of the offsets topic is the configured value, the number of alive brokers has to be at least the replication factor at the time of the first request for the offsets topic. If not, either the offsets topic creation will fail or it will get a replication factor of min(alive brokers, configured replication factor)",
+          "type": "integer",
+          "default": 3
+        },
+        "offsets_topic_segment_bytes": {
+          "title": "offsets.topic.segment.bytes",
+          "description": "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
+          "type": "integer",
+          "default": 104857600
+        },
+        "queued_max_requests": {
+          "title": "queued.max.requests",
+          "description": "The number of queued requests allowed before blocking the network threads ",
+          "type": "integer",
+          "default": 500
+        },
+        "quota_consumer_default": {
+          "title": "quota.consumer.default",
+          "description": "Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "quota_producer_default": {
+          "title": "quota.producer.default",
+          "description": "Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "replica_fetch_max_bytes": {
+          "title": "replica.fetch.max.bytes",
+          "description": "The number of byes of messages to attempt to fetch",
+          "type": "integer",
+          "default": 1048576
+        },
+        "replica_fetch_min_bytes": {
+          "title": "replica.fetch.min.bytes",
+          "description": "Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs",
+          "type": "integer",
+          "default": 1
+        },
+        "replica_fetch_wait_max_ms": {
+          "title": "replica.fetch.wait.max.ms",
+          "description": "Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics",
+          "type": "integer",
+          "default": 500
+        },
+        "replica_high_watermark_checkpoint_interval_ms": {
+          "title": "replica.high.watermark.checkpoint.interval.ms",
+          "description": "The frequency with which the high watermark is saved out to disk",
+          "type": "integer",
+          "default": 5000
+        },
+        "replica_lag_time_max_ms": {
+          "title": "replica.lag.time.max.ms",
+          "description": "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr",
+          "type": "integer",
+          "default": 10000
+        },
+        "replica_socket_receive_buffer_bytes": {
+          "title": "replica.socket.receive.buffer.bytes",
+          "description": "The socket receive buffer for network requests",
+          "type": "integer",
+          "default": 65536
+        },
+        "replica_socket_timeout_ms": {
+          "title": "replica.socket.timeout.ms",
+          "description": "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms",
+          "type": "integer",
+          "default": 30000
+        },
+        "request_timeout_ms": {
+          "title": "request.timeout.ms",
+          "description": "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.",
+          "type": "integer",
+          "default": 30000
+        },
+        "socket_receive_buffer_bytes": {
+          "title": "socket.receive.buffer.bytes",
+          "description": "The SO_RCVBUF buffer of the socket sever sockets",
+          "type": "integer",
+          "default": 102400
+        },
+        "socket_request_max_bytes": {
+          "title": "socket.request.max.bytes",
+          "description": "The maximum number of bytes in a socket request",
+          "type": "integer",
+          "default": 104857600
+        },
+        "socket_send_buffer_bytes": {
+          "title": "socket.send.buffer.bytes",
+          "description": "The SO_SNDBUF buffer of the socket sever sockets",
+          "type": "integer",
+          "default": 102400
+        },
+        "unclean_leader_election_enable": {
+          "title": "unclean.leader.election.enable",
+          "description": "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss",
+          "type": "boolean",
+          "default": true
+        },
+        "zookeeper_session_timeout_ms": {
+          "title": "zookeeper.session.timeout.ms",
+          "description": "Zookeeper session timeout",
+          "type": "integer",
+          "default": 6000
+        },
+        "connections_max_idle_ms": {
+          "title": "connections.max.idle.ms",
+          "description": "Idle connections timeout: the server socket processor threads close the connections that idle more than this",
+          "type": "integer",
+          "default": 600000
+        },
+        "controlled_shutdown_enable": {
+          "title": "controlled.shutdown.enable",
+          "description": "Enable controlled shutdown of the server",
+          "type": "boolean",
+          "default": true
+        },
+        "controlled_shutdown_max_retries": {
+          "title": "controlled.shutdown.max.retries",
+          "description": "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens",
+          "type": "integer",
+          "default": 3
+        },
+        "controlled_shutdown_retry_backoff_ms": {
+          "title": "controlled.shutdown.retry.backoff.ms",
+          "description": "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.",
+          "type": "integer",
+          "default": 5000
+        },
+        "controller_socket_timeout_ms": {
+          "title": "controller.socket.timeout.ms",
+          "description": "The socket timeout for controller-to-broker channels",
+          "type": "integer",
+          "default": 30000
+        },
+        "default_replication_factor": {
+          "title": "default.replication.factor",
+          "description": "Default replication factors for automatically created topics",
+          "type": "integer",
+          "default": 1
+        },
+        "fetch_purgatory_purge_interval_requests": {
+          "title": "fetch.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the fetch request purgatory",
+          "type": "integer",
+          "default": 1000
+        },
+        "group_max_session_timeout_ms": {
+          "title": "group.max.session.timeout.ms",
+          "description": "The maximum allowed session timeout for registered consumers",
+          "type": "integer",
+          "default": 300000
+        },
+        "group_min_session_timeout_ms": {
+          "title": "group.min.session.timeout.ms",
+          "description": "The minimum allowed session timeout for registered consumers",
+          "type": "integer",
+          "default": 6000
+        },
+        "inter_broker_protocol_version": {
+          "type": "string",
+          "title": "inter.broker.protocol.version",
+          "description": "Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped *serially* one broker at a time, *after* all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0, 0.10.1.x, 0.10.2.x, 0.11.0.0. Check ApiVersion for the full list.",
+          "default": "0.11.0.0"
+        },
+        "log_message_format_version": {
+          "type": "string",
+          "title": "log.message.format.version",
+          "description": "Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Similarly it should be left at 0.10.0 until all clients are updated to 0.11.0. This is typically bumped *serially* one broker at a time, *after* all inter-protocol versions are updated. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details.",
+          "default": "0.11.0"
+        },
+        "log_cleaner_backoff_ms": {
+          "title": "log.cleaner.backoff.ms",
+          "description": "The amount of time to sleep when there are no logs to clean",
+          "type": "integer",
+          "default": 15000
+        },
+        "log_cleaner_dedupe_buffer_size": {
+          "title": "log.cleaner.dedupe.buffer.size",
+          "description": "The total memory used for log deduplication across all cleaner threads",
+          "type": "integer",
+          "default": 134217728
+        },
+        "log_cleaner_delete_retention_ms": {
+          "title": "log.cleaner.delete.retention.ms",
+          "description": "How long are delete records retained?",
+          "type": "integer",
+          "default": 86400000
+        },
+        "log_cleaner_enable": {
+          "title": "log.cleaner.enable",
+          "description": "Enable the log cleaner process to run on the server? Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
+          "type": "boolean",
+          "default": true
+        },
+        "log_cleaner_io_buffer_load_factor": {
+          "title": "log.cleaner.io.buffer.load.factor",
+          "description": "Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions",
+          "type": "number",
+          "default": 0.9
+        },
+        "log_cleaner_io_buffer_size": {
+          "title": "log.cleaner.io.buffer.size",
+          "description": "The total memory used for log cleaner I/O buffers across all cleaner threads",
+          "type": "integer",
+          "default": 524288
+        },
+        "log_cleaner_io_max_bytes_per_second": {
+          "title": "log.cleaner.io.max.bytes.per.second",
+          "description": "The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average",
+          "type": "number",
+          "default": 1.7976931348623157e+308
+        },
+        "log_cleaner_min_cleanable_ratio": {
+          "title": "log.cleaner.min.cleanable.ratio",
+          "description": "The minimum ratio of dirty log to total log for a log to eligible for cleaning",
+          "type": "number",
+          "default": 0.5
+        },
+        "log_cleaner_threads": {
+          "title": "log.cleaner.threads",
+          "description": "The number of background threads to use for log cleaning",
+          "type": "integer",
+          "default": 1
+        },
+        "log_cleanup_policy": {
+          "type": "string",
+          "title": "log.cleanup.policy",
+          "description": "The default cleanup policy for segments beyond the retention window, must be either 'delete' or 'compact'",
+          "default": "delete"
+        },
+        "log_index_interval_bytes": {
+          "title": "log.index.interval.bytes",
+          "description": "The interval with which we add an entry to the offset index",
+          "type": "integer",
+          "default": 4096
+        },
+        "log_index_size_max_bytes": {
+          "title": "log.index.size.max.bytes",
+          "description": "The maximum size in bytes of the offset index",
+          "type": "integer",
+          "default": 10485760
+        },
+        "log_preallocate": {
+          "title": "log.preallocate",
+          "description": "Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.",
+          "type": "boolean",
+          "default": false
+        },
+        "log_retention_check_interval_ms": {
+          "title": "log.retention.check.interval.ms",
+          "description": "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion",
+          "type": "integer",
+          "default": 300000
+        },
+        "max_connections_per_ip": {
+          "title": "max.connections.per.ip",
+          "description": "mum number of connections we allow from each ip address",
+          "type": "integer",
+          "default": 2147483647
+        },
+        "max_connections_per_ip_overrides": {
+          "type": "string",
+          "title": "max.connections.per.ip.overrides",
+          "description": "Per-ip or hostname overrides to the default maximum number of connections",
+          "default": ""
+        },
+        "num_partitions": {
+          "title": "num.partitions",
+          "description": "The default number of log partitions per topic",
+          "type": "integer",
+          "default": 1
+        },
+        "producer_purgatory_purge_interval_requests": {
+          "title": "producer.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the producer request purgatory",
+          "type": "integer",
+          "default": 1000
+        },
+        "replica_fetch_backoff_ms": {
+          "title": "replica.fetch.backoff.ms",
+          "description": "The amount of time to sleep when fetch partition error occurs.",
+          "type": "integer",
+          "default": 1000
+        },
+        "reserved_broker_max_id": {
+          "title": "reserved.broker.max.id",
+          "description": "Max number that can be used for a broker.id",
+          "type": "integer",
+          "default": 1000
+        },
+        "kafka_metrics_reporters": {
+          "title": "kafka.metric.reporters",
+          "description": "Old style metrics reporter",
+          "type": "string",
+          "default": "com.airbnb.kafka.kafka08.StatsdMetricsReporter"
+        },
+        "metric_reporters": {
+          "title": "metric.reporters",
+          "description": "Java class to collect/report broker metrics",
+          "type": "string",
+          "default": "com.airbnb.kafka.kafka09.StatsdMetricsReporter"
+        },
+        "metrics_num_samples": {
+          "title": "metrics.num.samples",
+          "description": "The number of samples maintained to compute metrics.",
+          "type": "integer",
+          "default": 2
+        },
+        "metrics_sample_window_ms": {
+          "title": "metrics.sample.window.ms",
+          "description": "The number of samples maintained to compute metrics.",
+          "type": "integer",
+          "default": 30000
+        },
+        "quota_window_num": {
+          "title": "quota.window.num",
+          "description": "The number of samples to retain in memory",
+          "type": "integer",
+          "default": 11
+        },
+        "quota_window_size_seconds": {
+          "title": "quota.window.size.seconds",
+          "description": "The time span of each sample",
+          "type": "integer",
+          "default": 1
+        },
+        "zookeeper_sync_time_ms": {
+          "title": "zookeeper.sync.time.ms",
+          "description": "How far a ZK follower can be behind a ZK leader",
+          "type": "integer",
+          "default": 2000
         }
       }
     }
+  }
 }
--- 39/marathon.json.mustache
+++ 40/marathon.json.mustache
@@ -1,201 +1,211 @@
 {
   "id": "{{service.name}}",
   "cpus": 1.0,
-  "mem": 1230,
+  "mem": 1024,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export PATH=$(ls -d $MESOS_SANDBOX/jre*/bin):$PATH && ./scheduler/bin/kafka-scheduler server ./scheduler/conf/scheduler.yml",
+  "user":"{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./kafka-scheduler/bin/kafka ./kafka-scheduler/svc.yml",
   "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
-    "DCOS_MIGRATION_API_VERSION": "v1",
-    "DCOS_MIGRATION_API_PATH": "/v1/plan",
-    "MARATHON_SINGLE_INSTANCE_APP":"true",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
     "DCOS_SERVICE_NAME": "{{service.name}}",
-    "DCOS_SERVICE_PORT_INDEX": "1",
+    "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"
   },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
   "env": {
-    "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
-    "JAVA_HOME":"./jre1.8.0_121",
     "FRAMEWORK_NAME": "{{service.name}}",
-    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
-    "USER": "{{service.user}}",
-    "PLACEMENT_CONSTRAINT": "{{service.placement_constraint}}",
-    "PLACEMENT_STRATEGY": "{{service.placement_strategy}}",
-    "PHASE_STRATEGY": "{{service.phase_strategy}}",
-    "ENABLE_REPLACEMENT": "{{service.enable_replacement}}",
-    "RECOVERY_GRACE_PERIOD_SEC": "{{service.recover_in_place_grace_period_secs}}",
-    "REPLACE_DELAY_SEC": "{{service.min_delay_between_recovers_secs}}",
-    "ENABLE_BROKER_HEALTH_CHECK": "{{service.enable_health_check}}",
-    "BROKER_HEALTH_CHECK_DELAY_SEC": "{{service.health_check_delay_sec}}",
-    "BROKER_HEALTH_CHECK_INTERVAL_SEC": "{{service.health_check_interval_sec}}",
-    "BROKER_HEALTH_CHECK_TIMEOUT_SEC": "{{service.health_check_timeout_sec}}",
-    "BROKER_HEALTH_CHECK_MAX_FAILURES": "{{service.health_check_max_consecutive_failures}}",
-    "BROKER_HEALTH_CHECK_GRACE_SEC": "{{service.health_check_grace_period_sec}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    {{#brokers.kill_grace_period}}
+    "BROKER_KILL_GRACE_PERIOD": "{{brokers.kill_grace_period}}",
+    {{/brokers.kill_grace_period}}
+    "CMD_PREFIX": "{{service.cmd_prefix}}",
+    "SECRET_NAME": "{{service.secret_name}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "KAFKA_URI": "{{resource.assets.uris.kafka-tgz}}",
+    "KAFKA_JAVA_URI": "{{resource.assets.uris.kafka-jre-tar-gz}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "KAFKA_STATSD_URI": "{{resource.assets.uris.kafka-statsd-jar}}",
+    "CLIENT_STATSD_URI": "{{resource.assets.uris.statsd-client-jar}}",
+
+    "PLACEMENT_CONSTRAINTS": "{{service.placement_constraint}}",
+    "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",
     "BROKER_COUNT": "{{brokers.count}}",
     "BROKER_CPUS": "{{brokers.cpus}}",
     "BROKER_MEM": "{{brokers.mem}}",
-    "BROKER_HEAP_MB": "{{brokers.heap.size}}",
-    "BROKER_DISK": "{{brokers.disk}}",
+    "BROKER_DISK_SIZE": "{{brokers.disk}}",
+    "BROKER_DISK_TYPE": "{{brokers.disk_type}}",
+    "BROKER_DISK_PATH": "{{brokers.disk_path}}",
+    "BROKER_JAVA_HEAP": "{{brokers.heap.size}}",
     "BROKER_PORT": "{{brokers.port}}",
-    "BROKER_JMX_ENABLE": "{{brokers.jmx.enable}}",
-    "BROKER_JMX_REMOTE_ENABLE": "{{brokers.jmx.remote}}",
-    "BROKER_JMX_REMOTE_PORT": "{{brokers.jmx.remote_port}}",
-    "BROKER_JMX_REMOTE_REGISTRY_SSL": "{{brokers.jmx.remote_registry_ssl}}",
-    "BROKER_JMX_REMOTE_SSL": "{{brokers.jmx.remote_ssl}}",
-    "BROKER_JMX_REMOTE_AUTH": "{{brokers.jmx.remote_authenticate}}",
-    "BROKER_JMX_REMOTE_SSL_NEED_CLIENT_AUTH": "{{brokers.jmx.remote_ssl_need_client_auth}}",
-    "BROKER_STATSD_HOST": "{{brokers.statsd.host}}",
-    "BROKER_STATSD_PORT": "{{brokers.statsd.port}}",
-    "DISK_TYPE": "{{brokers.disk_type}}",
-    "KAFKA_VER_NAME": "kafka_2.11-0.10.1.0",
-    "KAFKA_URI": "{{resource.assets.uris.kafka_tgz}}",
-    "OVERRIDER_URI": "{{resource.assets.uris.overrider-zip}}",
-    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
-    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
-    "KAFKA_ZOOKEEPER_URI" : "{{kafka.kafka_zookeeper_uri}}",
-    "KAFKA_ADVERTISE_HOST_IP" : "{{kafka.kafka_advertise_host_ip}}",
-    "KAFKA_OVERRIDE_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",
-    "KAFKA_OVERRIDE_OFFSETS_TOPIC_COMPRESSION_CODEC": "{{kafka.offsets_topic_compression_codec}}",
-    "KAFKA_OVERRIDE_REPLICA_FETCH_MIN_BYTES": "{{kafka.replica_fetch_min_bytes}}",
-    "KAFKA_OVERRIDE_CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS": "{{kafka.controlled_shutdown_retry_backoff_ms}}",
-    "KAFKA_OVERRIDE_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_offset_checkpoint_interval_ms}}",
-    "KAFKA_OVERRIDE_OFFSETS_TOPIC_NUM_PARTITIONS": "{{kafka.offsets_topic_num_partitions}}",
-    "KAFKA_OVERRIDE_MAX_CONNECTIONS_PER_IP_OVERRIDES": "{{kafka.max_connections_per_ip_overrides}}",
-    "KAFKA_OVERRIDE_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS": "{{kafka.leader_imbalance_check_interval_seconds}}",
-    "KAFKA_OVERRIDE_INTER_BROKER_PROTOCOL_VERSION": "{{kafka.inter_broker_protocol_version}}",
-    "KAFKA_OVERRIDE_LOG_MESSAGE_FORMAT_VERSION": "{{kafka.log_message_format_version}}",
-    "KAFKA_OVERRIDE_REPLICA_SOCKET_TIMEOUT_MS": "{{kafka.replica_socket_timeout_ms}}",
-    "KAFKA_OVERRIDE_GROUP_MAX_SESSION_TIMEOUT_MS": "{{kafka.group_max_session_timeout_ms}}",
-    "KAFKA_OVERRIDE_METRICS_NUM_SAMPLES": "{{kafka.metrics_num_samples}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_DELETE_RETENTION_MS": "{{kafka.log_cleaner_delete_retention_ms}}",
-    "KAFKA_OVERRIDE_LOG_PREALLOCATE": "{{kafka.log_preallocate}}",
-    "KAFKA_OVERRIDE_REPLICA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.replica_socket_receive_buffer_bytes}}",
-    "KAFKA_OVERRIDE_OFFSET_METADATA_MAX_BYTES": "{{kafka.offset_metadata_max_bytes}}",
-    "KAFKA_OVERRIDE_MESSAGE_MAX_BYTES": "{{kafka.message_max_bytes}}",
-    "KAFKA_OVERRIDE_LOG_ROLL_JITTER_HOURS": "{{kafka.log_roll_jitter_hours}}",
-    "KAFKA_OVERRIDE_OFFSETS_RETENTION_CHECK_INTERVAL_MS": "{{kafka.offsets_retention_check_interval_ms}}",
-    "KAFKA_OVERRIDE_FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.fetch_purgatory_purge_interval_requests}}",
-    "KAFKA_OVERRIDE_LOG_RETENTION_CHECK_INTERVAL_MS": "{{kafka.log_retention_check_interval_ms}}",
-    "KAFKA_OVERRIDE_LOG_INDEX_INTERVAL_BYTES": "{{kafka.log_index_interval_bytes}}",
-    "KAFKA_OVERRIDE_NUM_NETWORK_THREADS": "{{kafka.num_network_threads}}",
-    "KAFKA_OVERRIDE_OFFSETS_COMMIT_TIMEOUT_MS": "{{kafka.offsets_commit_timeout_ms}}",
-    "KAFKA_OVERRIDE_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{kafka.offsets_topic_replication_factor}}",
-    "KAFKA_OVERRIDE_REPLICA_FETCH_MAX_BYTES": "{{kafka.replica_fetch_max_bytes}}",
-    "KAFKA_OVERRIDE_CONNECTIONS_MAX_IDLE_MS": "{{kafka.connections_max_idle_ms}}",
-    "KAFKA_OVERRIDE_SOCKET_REQUEST_MAX_BYTES": "{{kafka.socket_request_max_bytes}}",
-    "KAFKA_OVERRIDE_METRICS_SAMPLE_WINDOW_MS": "{{kafka.metrics_sample_window_ms}}",
-    "KAFKA_OVERRIDE_NUM_PARTITIONS": "{{kafka.num_partitions}}",
-    "KAFKA_OVERRIDE_REPLICA_LAG_TIME_MAX_MS": "{{kafka.replica_lag_time_max_ms}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_IO_BUFFER_LOAD_FACTOR": "{{kafka.log_cleaner_io_buffer_load_factor}}",
-    "KAFKA_OVERRIDE_OFFSETS_COMMIT_REQUIRED_ACKS": "{{kafka.offsets_commit_required_acks}}",
-    "KAFKA_OVERRIDE_AUTO_CREATE_TOPICS_ENABLE": "{{kafka.auto_create_topics_enable}}",
-    "KAFKA_OVERRIDE_UNCLEAN_LEADER_ELECTION_ENABLE": "{{kafka.unclean_leader_election_enable}}",
-    "KAFKA_OVERRIDE_REPLICA_FETCH_BACKOFF_MS": "{{kafka.replica_fetch_backoff_ms}}",
-    "KAFKA_OVERRIDE_LOG_ROLL_HOURS": "{{kafka.log_roll_hours}}",
-    "KAFKA_OVERRIDE_ZOOKEEPER_SESSION_TIMEOUT_MS": "{{kafka.zookeeper_session_timeout_ms}}",
-    "KAFKA_OVERRIDE_PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.producer_purgatory_purge_interval_requests}}",
-    "KAFKA_OVERRIDE_GROUP_MIN_SESSION_TIMEOUT_MS": "{{kafka.group_min_session_timeout_ms}}",
-    "KAFKA_OVERRIDE_LOG_INDEX_SIZE_MAX_BYTES": "{{kafka.log_index_size_max_bytes}}",
-    "KAFKA_OVERRIDE_NUM_REPLICA_FETCHERS": "{{kafka.num_replica_fetchers}}",
-    "KAFKA_OVERRIDE_MIN_INSYNC_REPLICAS": "{{kafka.min_insync_replicas}}",
-    "KAFKA_OVERRIDE_LOG_FLUSH_INTERVAL_MESSAGES": "{{kafka.log_flush_interval_messages}}",
-    "KAFKA_OVERRIDE_SOCKET_SEND_BUFFER_BYTES": "{{kafka.socket_send_buffer_bytes}}",
-    "KAFKA_OVERRIDE_AUTO_LEADER_REBALANCE_ENABLE": "{{kafka.auto_leader_rebalance_enable}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_ENABLE": "{{kafka.log_cleaner_enable}}",
-    "KAFKA_OVERRIDE_QUEUED_MAX_REQUESTS": "{{kafka.queued_max_requests}}",
-    "KAFKA_OVERRIDE_CONTROLLED_SHUTDOWN_MAX_RETRIES": "{{kafka.controlled_shutdown_max_retries}}",
-    "KAFKA_OVERRIDE_OFFSETS_LOAD_BUFFER_SIZE": "{{kafka.offsets_load_buffer_size}}",
-    "KAFKA_OVERRIDE_LOG_RETENTION_BYTES": "{{kafka.log_retention_bytes}}",
-    "KAFKA_OVERRIDE_NUM_IO_THREADS": "{{kafka.num_io_threads}}",
-    "KAFKA_OVERRIDE_CONTROLLER_SOCKET_TIMEOUT_MS": "{{kafka.controller_socket_timeout_ms}}",
-    "KAFKA_OVERRIDE_LOG_RETENTION_HOURS": "{{kafka.log_retention_hours}}",
-    "KAFKA_OVERRIDE_LOG_FLUSH_SCHEDULER_INTERVAL_MS": "{{kafka.log_flush_scheduler_interval_ms}}",
-    "KAFKA_OVERRIDE_OFFSETS_RETENTION_MINUTES": "{{kafka.offsets_retention_minutes}}",
-    "KAFKA_OVERRIDE_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.quota_window_size_seconds}}",
-    "KAFKA_OVERRIDE_LOG_SEGMENT_BYTES": "{{kafka.log_segment_bytes}}",
-    "KAFKA_OVERRIDE_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE": "{{kafka.leader_imbalance_per_broker_percentage}}",
-    "KAFKA_OVERRIDE_MAX_CONNECTIONS_PER_IP": "{{kafka.max_connections_per_ip}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_DEDUPE_BUFFER_SIZE": "{{kafka.log_cleaner_dedupe_buffer_size}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_MIN_CLEANABLE_RATIO": "{{kafka.log_cleaner_min_cleanable_ratio}}",
-    "KAFKA_OVERRIDE_ZOOKEEPER_SYNC_TIME_MS": "{{kafka.zookeeper_sync_time_ms}}",
-    "KAFKA_OVERRIDE_QUOTA_CONSUMER_DEFAULT": "{{kafka.quota_consumer_default}}",
-    "KAFKA_OVERRIDE_DELETE_TOPIC_ENABLE": "{{kafka.delete_topic_enable}}",
-    "KAFKA_OVERRIDE_LOG_CLEANUP_POLICY": "{{kafka.log_cleanup_policy}}",
-    "KAFKA_OVERRIDE_DEFAULT_REPLICATION_FACTOR": "{{kafka.default_replication_factor}}",
-    "KAFKA_OVERRIDE_NUM_RECOVERY_THREADS_PER_DATA_DIR": "{{kafka.num_recovery_threads_per_data_dir}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_IO_BUFFER_SIZE": "{{kafka.log_cleaner_io_buffer_size}}",
-    "KAFKA_OVERRIDE_BACKGROUND_THREADS": "{{kafka.background_threads}}",
-    "KAFKA_OVERRIDE_LOG_SEGMENT_DELETE_DELAY_MS": "{{kafka.log_segment_delete_delay_ms}}",
-    "KAFKA_OVERRIDE_QUOTA_WINDOW_NUM": "{{kafka.quota_window_num}}",
-    "KAFKA_OVERRIDE_REQUEST_TIMEOUT_MS": "{{kafka.request_timeout_ms}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_THREADS": "{{kafka.log_cleaner_threads}}",
-    "KAFKA_OVERRIDE_QUOTA_PRODUCER_DEFAULT": "{{kafka.quota_producer_default}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_BACKOFF_MS": "{{kafka.log_cleaner_backoff_ms}}",
-    "KAFKA_OVERRIDE_CONTROLLED_SHUTDOWN_ENABLE": "{{kafka.controlled_shutdown_enable}}",
-    "KAFKA_OVERRIDE_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.socket_receive_buffer_bytes}}",
-    "KAFKA_OVERRIDE_REPLICA_FETCH_WAIT_MAX_MS": "{{kafka.replica_fetch_wait_max_ms}}",
-    "KAFKA_OVERRIDE_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS": "{{kafka.replica_high_watermark_checkpoint_interval_ms}}",
-    "KAFKA_OVERRIDE_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
-    "KAFKA_OVERRIDE_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
-    "KAFKA_OVERRIDE_COMPRESSION_TYPE": "{{kafka.compression_type}}"
-    {{#service.secret_name}}
-    ,"DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
     "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
-    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee"
-    {{/service.secret_name}}
-  },
-  {{#service.secret_name}}
-  "secrets": {
-    "serviceCredential": {
-      "source": "{{service.secret_name}}"
-    }
-  },
-  {{/service.secret_name}}
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    {{#service.tls}}
+    "BROKER_PORT_TLS": "{{brokers.port_tls}}",
+    "TASKCFG_ALL_KAFKA_ENABLE_TLS": "{{service.tls}}",
+    {{#service.tls_allow_plaintext}}
+    "TASKCFG_ALL_KAFKA_ALLOW_PLAINTEXT": "{{service.tls_allow_plaintext}}",
+    {{/service.tls_allow_plaintext}}
+    {{/service.tls}}
+
+    "CONFIG_TEMPLATE_PATH": "kafka-scheduler",
+    "KAFKA_VERSION_PATH": "kafka_2.12-0.11.0.0",
+
+    "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
+
+    {{#kafka.kafka_advertise_host_ip}}
+    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "set",
+    {{/kafka.kafka_advertise_host_ip}}
+
+    "TASKCFG_ALL_KAFKA_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_COMPRESSION_CODEC": "{{kafka.offsets_topic_compression_codec}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MIN_BYTES": "{{kafka.replica_fetch_min_bytes}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS": "{{kafka.controlled_shutdown_retry_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_offset_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS": "{{kafka.offsets_topic_num_partitions}}",
+    "TASKCFG_ALL_KAFKA_MAX_CONNECTIONS_PER_IP_OVERRIDES": "{{kafka.max_connections_per_ip_overrides}}",
+    "TASKCFG_ALL_KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS": "{{kafka.leader_imbalance_check_interval_seconds}}",
+    "TASKCFG_ALL_KAFKA_INTER_BROKER_PROTOCOL_VERSION": "{{kafka.inter_broker_protocol_version}}",
+    "TASKCFG_ALL_KAFKA_LOG_MESSAGE_FORMAT_VERSION": "{{kafka.log_message_format_version}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_SOCKET_TIMEOUT_MS": "{{kafka.replica_socket_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_GROUP_MAX_SESSION_TIMEOUT_MS": "{{kafka.group_max_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_DELETE_RETENTION_MS": "{{kafka.log_cleaner_delete_retention_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_PREALLOCATE": "{{kafka.log_preallocate}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.replica_socket_receive_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_OFFSET_METADATA_MAX_BYTES": "{{kafka.offset_metadata_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_MESSAGE_MAX_BYTES": "{{kafka.message_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_JITTER_HOURS": "{{kafka.log_roll_jitter_hours}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_RETENTION_CHECK_INTERVAL_MS": "{{kafka.offsets_retention_check_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.fetch_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS": "{{kafka.log_retention_check_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_INDEX_INTERVAL_BYTES": "{{kafka.log_index_interval_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_NETWORK_THREADS": "{{kafka.num_network_threads}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_COMMIT_TIMEOUT_MS": "{{kafka.offsets_commit_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{kafka.offsets_topic_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MAX_BYTES": "{{kafka.replica_fetch_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_CONNECTIONS_MAX_IDLE_MS": "{{kafka.connections_max_idle_ms}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_REQUEST_MAX_BYTES": "{{kafka.socket_request_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_METRICS_REPORTERS": "{{kafka.kafka_metrics_reporters}}",
+    "TASKCFG_ALL_METRIC_REPORTERS": "{{kafka.metric_reporters}}",
+    "TASKCFG_ALL_KAFKA_METRICS_NUM_SAMPLES": "{{kafka.metrics_num_samples}}",
+    "TASKCFG_ALL_KAFKA_METRICS_SAMPLE_WINDOW_MS": "{{kafka.metrics_sample_window_ms}}",
+    "TASKCFG_ALL_KAFKA_NUM_PARTITIONS": "{{kafka.num_partitions}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_LAG_TIME_MAX_MS": "{{kafka.replica_lag_time_max_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_BUFFER_LOAD_FACTOR": "{{kafka.log_cleaner_io_buffer_load_factor}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_COMMIT_REQUIRED_ACKS": "{{kafka.offsets_commit_required_acks}}",
+    "TASKCFG_ALL_KAFKA_AUTO_CREATE_TOPICS_ENABLE": "{{kafka.auto_create_topics_enable}}",
+    "TASKCFG_ALL_KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE": "{{kafka.unclean_leader_election_enable}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_BACKOFF_MS": "{{kafka.replica_fetch_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_HOURS": "{{kafka.log_roll_hours}}",
+    "TASKCFG_ALL_KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS": "{{kafka.zookeeper_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.producer_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS": "{{kafka.group_min_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_INDEX_SIZE_MAX_BYTES": "{{kafka.log_index_size_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_REPLICA_FETCHERS": "{{kafka.num_replica_fetchers}}",
+    "TASKCFG_ALL_KAFKA_MIN_INSYNC_REPLICAS": "{{kafka.min_insync_replicas}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_INTERVAL_MESSAGES": "{{kafka.log_flush_interval_messages}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_SEND_BUFFER_BYTES": "{{kafka.socket_send_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_AUTO_LEADER_REBALANCE_ENABLE": "{{kafka.auto_leader_rebalance_enable}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_ENABLE": "{{kafka.log_cleaner_enable}}",
+    "TASKCFG_ALL_KAFKA_QUEUED_MAX_REQUESTS": "{{kafka.queued_max_requests}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_MAX_RETRIES": "{{kafka.controlled_shutdown_max_retries}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_LOAD_BUFFER_SIZE": "{{kafka.offsets_load_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_BYTES": "{{kafka.log_retention_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_IO_THREADS": "{{kafka.num_io_threads}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLER_SOCKET_TIMEOUT_MS": "{{kafka.controller_socket_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_HOURS": "{{kafka.log_retention_hours}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_SCHEDULER_INTERVAL_MS": "{{kafka.log_flush_scheduler_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_RETENTION_MINUTES": "{{kafka.offsets_retention_minutes}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.quota_window_size_seconds}}",
+    "TASKCFG_ALL_KAFKA_LOG_SEGMENT_BYTES": "{{kafka.log_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE": "{{kafka.leader_imbalance_per_broker_percentage}}",
+    "TASKCFG_ALL_KAFKA_MAX_CONNECTIONS_PER_IP": "{{kafka.max_connections_per_ip}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_DEDUPE_BUFFER_SIZE": "{{kafka.log_cleaner_dedupe_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO": "{{kafka.log_cleaner_min_cleanable_ratio}}",
+    "TASKCFG_ALL_KAFKA_ZOOKEEPER_SYNC_TIME_MS": "{{kafka.zookeeper_sync_time_ms}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_CONSUMER_DEFAULT": "{{kafka.quota_consumer_default}}",
+    "TASKCFG_ALL_KAFKA_DELETE_TOPIC_ENABLE": "{{kafka.delete_topic_enable}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANUP_POLICY": "{{kafka.log_cleanup_policy}}",
+    "TASKCFG_ALL_KAFKA_DEFAULT_REPLICATION_FACTOR": "{{kafka.default_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR": "{{kafka.num_recovery_threads_per_data_dir}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_BUFFER_SIZE": "{{kafka.log_cleaner_io_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_BACKGROUND_THREADS": "{{kafka.background_threads}}",
+    "TASKCFG_ALL_KAFKA_LOG_SEGMENT_DELETE_DELAY_MS": "{{kafka.log_segment_delete_delay_ms}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_WINDOW_NUM": "{{kafka.quota_window_num}}",
+    "TASKCFG_ALL_KAFKA_REQUEST_TIMEOUT_MS": "{{kafka.request_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_THREADS": "{{kafka.log_cleaner_threads}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_PRODUCER_DEFAULT": "{{kafka.quota_producer_default}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_BACKOFF_MS": "{{kafka.log_cleaner_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_ENABLE": "{{kafka.controlled_shutdown_enable}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.socket_receive_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_WAIT_MAX_MS": "{{kafka.replica_fetch_wait_max_ms}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS": "{{kafka.replica_high_watermark_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
+    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}"
+  },
   "uris": [
-    "{{resource.assets.uris.jre-tar-gz}}",
-    "{{resource.assets.uris.scheduler-zip}}",
-    "{{resource.assets.uris.kafka_tgz}}",
-    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
-  ],
-  "healthChecks": [
-    {
-      "gracePeriodSeconds": 120,
-      "intervalSeconds": 30,
-      "maxConsecutiveFailures": 0,
-      "path": "/admin/healthcheck",
-      "portIndex": 0,
-      "protocol": "HTTP",
-      "timeoutSeconds": 5
-    }
-  ],
-  "readinessChecks": [
-      {
-        "name": "kafkaUpdateProgress",
-        "protocol": "HTTP",
-        "path": "/v1/plan",
-        "portName": "api",
-        "interval": 10000,
-        "timeout": 10000,
-        "httpStatusCodesForReady": [200],
-        "preserveLastResponse": true
-      }
+    "{{resource.assets.uris.executor-zip}}",
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.kafka-scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.kafka-tgz}}",
+    "{{resource.assets.uris.jre-tar-gz}}"
   ],
   "upgradeStrategy":{
     "minimumHealthCapacity": 0,
     "maximumOverCapacity": 0
   },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
   "portDefinitions": [
     {
       "port": 0,
       "protocol": "tcp",
-      "name": "health",
-      "labels": {}
-    },
-    {
-      "port": 0,
-      "protocol": "tcp",
       "name": "api",
-      "labels": {}
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
     }
   ]
 }
--- 39/package.json
+++ 40/package.json
@@ -1,17 +1,19 @@
 {
-  "description": "Apache Kafka running on DC/OS",
+  "description": "Apache Kafka",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.7",
+  "minDcosReleaseVersion": "1.9",
   "name": "kafka",
   "packagingVersion": "3.0",
-  "postInstallNotes": "DC/OS Kafka Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/kafka/\n\tIssues: https://dcosjira.atlassian.net/projects/KAFKA/issues",
-  "postUninstallNotes": "DC/OS Kafka Service has been uninstalled.\nPlease follow the instructions at https://docs.mesosphere.com/current/usage/service-guides/kafka/uninstall to remove any persistent state if required.",
+  "postInstallNotes": "DC/OS Apache Kafka Service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/current/usage/service-guides/kafka\n\tIssues: https://dcosjira.atlassian.net/projects/KAFKA/issues",
+  "postUninstallNotes": "DC/OS Apache Kafka Service is being uninstalled.\nPlease follow the instructions at https://docs.mesosphere.com/current/usage/service-guides/kafka/uninstall to remove any persistent state if required.",
+  "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM | 1 5000 MB Disk\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "selected": false,
   "tags": [
     "message",
     "broker",
+    "kafka",
     "pubsub"
   ],
-  "version": "1.1.19.1-0.10.1.0"
+  "version": "2.0.0-0.11.0.0"
 }
--- 39/resource.json
+++ 40/resource.json
@@ -1,12 +1,15 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u121-linux-x64.tar.gz",
-      "kafka_tgz": "https://downloads.mesosphere.com/kafka/assets/kafka_2.11-0.10.1.0.tgz",
-      "scheduler-zip": "https://downloads.mesosphere.com/kafka/assets/1.1.19-0.10.1.0/scheduler.zip",
-      "executor-zip": "https://downloads.mesosphere.com/kafka/assets/1.1.19-0.10.1.0/executor.zip",
-      "overrider-zip": "https://downloads.mesosphere.com/kafka/assets/1.1.19-0.10.1.0/overrider.zip",
-      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.9-argus-1.1.x-3.tar.gz"
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "bootstrap-zip": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/bootstrap.zip",
+      "kafka-tgz": "https://s3.us-east-2.amazonaws.com/seglo-fdp-dev/static/kafka_2.12-0.11.0.0.tgz",
+      "kafka-jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
+      "kafka-scheduler-zip": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/kafka-scheduler.zip",
+      "executor-zip": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/executor.zip",
+      "kafka-statsd-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-statsd-metrics2-0.5.3.jar",
+      "statsd-client-jar": "http://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar"
     }
   },
   "images": {
@@ -14,27 +17,42 @@
     "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-medium.png",
     "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-large.png"
   },
-  "cli":{
-    "binaries":{
-      "darwin":{
-        "x86-64":{
-          "contentHash":[ { "algo":"sha256", "value":"660f143852b6d3d2b0b2f787fab9e5e2927f4440502a89c9e1c08488cdacc34f" } ],
-          "kind":"executable",
-          "url":"https://downloads.mesosphere.com/kafka/assets/1.1.19-0.10.1.0/dcos-kafka-darwin"
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "bd6c7c60788b5e61432e7239f1480506a1a7e144e1d25188737861af509a0449"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/dcos-kafka-darwin"
         }
       },
-      "linux":{
-        "x86-64":{
-          "contentHash":[ { "algo":"sha256", "value":"0b26409c9760fd4d75fca1114d01f25ec069147d578d6f337c88424ebc64c808" } ],
-          "kind":"executable",
-          "url":"https://downloads.mesosphere.com/kafka/assets/1.1.19-0.10.1.0/dcos-kafka-linux"
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "7c6aa8ba6e61b1b27089d65c604ae21d987efe46bb9dba44c147164f3f041c2b"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/dcos-kafka-linux"
         }
       },
-      "windows":{
-        "x86-64":{
-          "contentHash":[ { "algo":"sha256", "value":"60d6f802412b94833cf8db217af162e7dc35c0f5e0a1eb4b587268c361500c3b" } ],
-          "kind":"executable",
-          "url":"https://downloads.mesosphere.com/kafka/assets/1.1.19-0.10.1.0/dcos-kafka.exe"
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "65e3eeddca21a72295310e310d0cab46ea74646808de42d82c7d8309a10a421c"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://seglo-fdp-dev.s3.amazonaws.com/autodelete7d/kafka/20170830-151516-WcqRrTyKvUbxxPRz/dcos-kafka.exe"
         }
       }
     }
```
